### PR TITLE
Fix: Library tag grouping was hidden whole library if all groups have less or equal than 3 entries

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
@@ -5,8 +5,6 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.source.online.HttpSource
 import exh.source.BlacklistedSources
-import exh.source.DelegatedHttpSource
-import exh.source.EnhancedHttpSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -113,12 +111,6 @@ class AndroidSourceManager(
         .filterIsInstance<CatalogueSource>()
         .filter {
             it.id !in BlacklistedSources.HIDDEN_SOURCES
-        }
-
-    fun getDelegatedCatalogueSources() = sourcesMapFlow.value.values
-        .filterIsInstance<EnhancedHttpSource>()
-        .mapNotNull { enhancedHttpSource ->
-            enhancedHttpSource.enhancedSource as? DelegatedHttpSource
         }
     // SY <--
 

--- a/app/src/main/java/exh/source/BlacklistedSources.kt
+++ b/app/src/main/java/exh/source/BlacklistedSources.kt
@@ -1,14 +1,6 @@
 package exh.source
 
 object BlacklistedSources {
-    val EHENTAI_EXT_SOURCES = longArrayOf()
-
-    val BLACKLISTED_EXT_SOURCES = EHENTAI_EXT_SOURCES
-
-    val BLACKLISTED_EXTENSIONS = arrayOf(
-        "eu.kanade.tachiyomi.extension.all.ehentai",
-    )
-
     var HIDDEN_SOURCES = setOf(
         MERGED_SOURCE_ID,
     )


### PR DESCRIPTION
## Summary by Sourcery

Fix the library tag grouping logic to ensure that groups with 3 or fewer entries are not hidden entirely

Bug Fixes:
- Resolve an issue where library tag groups with 3 or fewer entries were being completely hidden from the library view

Enhancements:
- Improve tag grouping logic to handle small genre groups more effectively
- Add a default 'Ungrouped' tag for anime without genres

Chores:
- Remove unused source-related code in AndroidSourceManager and BlacklistedSources