### PR TITLE
feat: Add Jimaku subtitle integration for the player

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsSubtitleScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsSubtitleScreen.kt
@@ -2,12 +2,15 @@ package eu.kanade.presentation.more.settings.screen.player
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.presentation.more.settings.screen.SearchableSettings
 import eu.kanade.tachiyomi.ui.player.settings.SubtitlePreferences
+import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -40,6 +43,34 @@ object PlayerSettingsSubtitleScreen : SearchableSettings {
                 pref = blacklist,
                 title = stringResource(MR.strings.pref_player_subtitle_blacklist),
                 dialogSubtitle = stringResource(MR.strings.pref_player_subtitle_blacklist_info),
+            ),
+            getJimakuGroup(subtitlePreferences),
+        )
+    }
+
+    @Composable
+    private fun getJimakuGroup(subtitlePreferences: SubtitlePreferences): Preference.PreferenceGroup {
+        val jimakuEnabled by subtitlePreferences.jimakuEnabled().collectAsState()
+
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_jimaku_group),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = subtitlePreferences.jimakuEnabled(),
+                    title = stringResource(MR.strings.pref_jimaku_enabled),
+                    subtitle = stringResource(MR.strings.pref_jimaku_enabled_summary),
+                ),
+                Preference.PreferenceItem.EditTextPreference(
+                    pref = subtitlePreferences.jimakuApiKey(),
+                    title = stringResource(MR.strings.pref_jimaku_api_key),
+                    enabled = jimakuEnabled,
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = subtitlePreferences.jimakuAutoFetch(),
+                    title = stringResource(MR.strings.pref_jimaku_auto_fetch),
+                    subtitle = stringResource(MR.strings.pref_jimaku_auto_fetch_summary),
+                    enabled = jimakuEnabled,
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1288,6 +1288,13 @@ class PlayerActivity : BaseActivity() {
                 }
             }
         }
+
+        if (
+            viewModel.subtitlePreferences.jimakuEnabled().get() &&
+            viewModel.subtitlePreferences.jimakuAutoFetch().get()
+        ) {
+            viewModel.fetchAndAutoSelectJimaku()
+        }
     }
 
     private fun setupTracks() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -72,9 +72,21 @@ import eu.kanade.tachiyomi.ui.player.loader.EpisodeLoader
 import eu.kanade.tachiyomi.ui.player.loader.HosterLoader
 import eu.kanade.tachiyomi.ui.player.settings.GesturePreferences
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
+import eu.kanade.tachiyomi.ui.player.settings.SubtitlePreferences
 import eu.kanade.tachiyomi.ui.player.utils.AniSkipApi
 import eu.kanade.tachiyomi.ui.player.utils.ChapterUtils.Companion.getStringRes
+import eu.kanade.tachiyomi.ui.player.utils.JimakuApi
+import eu.kanade.tachiyomi.ui.player.utils.JimakuAuthException
+import eu.kanade.tachiyomi.ui.player.utils.JimakuEntry
+import eu.kanade.tachiyomi.ui.player.utils.JimakuFile
+import eu.kanade.tachiyomi.ui.player.utils.JimakuNetworkException
+import eu.kanade.tachiyomi.ui.player.utils.JimakuRateLimitException
+import eu.kanade.tachiyomi.ui.player.utils.JimakuUiError
 import eu.kanade.tachiyomi.ui.player.utils.TrackSelect
+import eu.kanade.tachiyomi.ui.player.utils.entryIdCacheKey
+import eu.kanade.tachiyomi.ui.player.utils.entrySearchCacheKey
+import eu.kanade.tachiyomi.ui.player.utils.fileListCacheKey
+import eu.kanade.tachiyomi.ui.player.utils.rankFileFormat
 import eu.kanade.tachiyomi.ui.reader.SaveImageNotifier
 import eu.kanade.tachiyomi.util.editCover
 import eu.kanade.tachiyomi.util.episode.filterDownloadedEpisodes
@@ -162,6 +174,8 @@ class PlayerViewModel @JvmOverloads constructor(
     private val basePreferences: BasePreferences = Injekt.get(),
     private val getCustomButtons: GetCustomButtons = Injekt.get(),
     private val trackSelect: TrackSelect = Injekt.get(),
+    internal val subtitlePreferences: SubtitlePreferences = Injekt.get(),
+    private val networkHelper: eu.kanade.tachiyomi.network.NetworkHelper = Injekt.get(),
     uiPreferences: UiPreferences = Injekt.get(),
 ) : ViewModel() {
 
@@ -202,6 +216,27 @@ class PlayerViewModel @JvmOverloads constructor(
     val subtitleTracks = _subtitleTracks.asStateFlow()
     private val _selectedSubtitles = MutableStateFlow(Pair(-1, -1))
     val selectedSubtitles = _selectedSubtitles.asStateFlow()
+
+    private val _jimakuFiles = MutableStateFlow<List<JimakuFile>>(emptyList())
+    val jimakuFiles = _jimakuFiles.asStateFlow()
+    private val _jimakuLoading = MutableStateFlow(false)
+    val jimakuLoading = _jimakuLoading.asStateFlow()
+    private val _jimakuError = MutableStateFlow<JimakuUiError?>(null)
+    val jimakuError = _jimakuError.asStateFlow()
+    private val _jimakuSelectedUrl = MutableStateFlow<String?>(null)
+    val jimakuSelectedUrl = _jimakuSelectedUrl.asStateFlow()
+    private val jimakuCachedFiles = mutableMapOf<String, java.io.File>()
+    private val jimakuEntryCache = mutableMapOf<String, List<JimakuEntry>>()
+    private val jimakuFileListCache = mutableMapOf<String, List<JimakuFile>>()
+    private var jimakuSearchJob: Job? = null
+    private var jimakuApiKey: String = ""
+    private var jimakuApi: JimakuApi? = null
+    private val _jimakuAddedUrls = MutableStateFlow<Set<String>>(emptySet())
+    val jimakuAddedUrls = _jimakuAddedUrls.asStateFlow()
+    private val _jimakuEntries = MutableStateFlow<List<JimakuEntry>>(emptyList())
+    val jimakuEntries = _jimakuEntries.asStateFlow()
+    private val _jimakuIsAllFiles = MutableStateFlow(false)
+    val jimakuIsAllFiles = _jimakuIsAllFiles.asStateFlow()
 
     private val _audioTracks = MutableStateFlow<List<VideoTrack>>(emptyList())
     val audioTracks = _audioTracks.asStateFlow()
@@ -533,6 +568,7 @@ class PlayerViewModel @JvmOverloads constructor(
         }
         activity.player.secondarySid = _selectedSubtitles.value.second
         activity.player.sid = _selectedSubtitles.value.first
+        _jimakuSelectedUrl.update { null }
     }
 
     fun updateSubtitle(sid: Int, secondarySid: Int) {
@@ -1910,6 +1946,263 @@ class PlayerViewModel @JvmOverloads constructor(
             }
         }
         return null
+    }
+
+    fun fetchAndAutoSelectJimaku() {
+        viewModelScope.launch {
+            val files = fetchJimakuSubtitles()
+            if (files.isNotEmpty()) {
+                autoSelectBestJimakuSubtitle(files)
+            }
+        }
+    }
+
+    fun fetchJimakuFiles(forceRefresh: Boolean) {
+        viewModelScope.launch { fetchJimakuSubtitles(forceRefresh) }
+    }
+
+    private fun getJimakuApi(): JimakuApi? {
+        val apiKey = subtitlePreferences.jimakuApiKey().get()
+        if (apiKey.isBlank()) {
+            _jimakuError.update { JimakuUiError.AuthError }
+            return null
+        }
+        if (jimakuApiKey != apiKey || jimakuApi == null) {
+            jimakuApiKey = apiKey
+            jimakuApi = JimakuApi(apiKey, activity.cacheDir, networkHelper.client)
+        }
+        return jimakuApi
+    }
+
+    private suspend inline fun getEntriesOrFetch(
+        cacheKey: String,
+        forceRefresh: Boolean,
+        fetch: suspend () -> List<JimakuEntry>,
+    ): List<JimakuEntry> {
+        if (!forceRefresh) {
+            jimakuEntryCache[cacheKey]?.let { return it }
+        }
+        return fetch().also { result ->
+            if (result.isNotEmpty()) {
+                jimakuEntryCache[cacheKey] = result
+            }
+        }
+    }
+
+    private suspend inline fun getFilesOrFetch(
+        cacheKey: String,
+        forceRefresh: Boolean,
+        fetch: suspend () -> List<JimakuFile>,
+    ): List<JimakuFile> {
+        if (!forceRefresh) {
+            jimakuFileListCache[cacheKey]?.let { return it }
+        }
+        return fetch().also { result ->
+            if (result.isNotEmpty()) {
+                jimakuFileListCache[cacheKey] = result
+            }
+        }
+    }
+
+    private suspend fun resolveJimakuEntries(jimakuApi: JimakuApi, forceRefresh: Boolean): List<JimakuEntry> {
+        val animeId = currentAnime.value?.id ?: return emptyList()
+
+        val trackerManager = Injekt.get<TrackerManager>()
+        val tracks = getTracks.await(animeId)
+        var result = emptyList<JimakuEntry>()
+
+        val anilistTrack = tracks.firstOrNull { track ->
+            trackerManager.get(track.trackerId) is Anilist
+        }
+        if (anilistTrack != null) {
+            result = getEntriesOrFetch(
+                cacheKey = entryIdCacheKey(anilistTrack.remoteId),
+                forceRefresh = forceRefresh,
+            ) {
+                jimakuApi.searchByAniListId(anilistTrack.remoteId)
+            }
+        }
+
+        if (result.isEmpty()) {
+            val malTrack = tracks.firstOrNull { track ->
+                trackerManager.get(track.trackerId) is MyAnimeList
+            }
+            if (malTrack != null) {
+                val alId = jimakuApi.getAniListIdFromMal(malTrack.remoteId)
+                if (alId > 0L) {
+                    result = getEntriesOrFetch(
+                        cacheKey = entryIdCacheKey(alId),
+                        forceRefresh = forceRefresh,
+                    ) {
+                        jimakuApi.searchByAniListId(alId)
+                    }
+                }
+            }
+        }
+
+        if (result.isEmpty()) {
+            val anime = currentAnime.value
+            val titlesToSearch = listOfNotNull(
+                anime?.ogTitle?.takeIf { it.isNotBlank() },
+                anime?.title?.takeIf { it.isNotBlank() && it != anime.ogTitle },
+            )
+
+            for (title in titlesToSearch) {
+                result = getEntriesOrFetch(
+                    cacheKey = entrySearchCacheKey(title),
+                    forceRefresh = forceRefresh,
+                ) {
+                    jimakuApi.searchByName(title)
+                }
+                if (result.isNotEmpty()) break
+            }
+        }
+
+        return result
+    }
+
+    private suspend fun fetchFilesForEntry(
+        jimakuApi: JimakuApi,
+        entryId: Long,
+        episodeNumber: Int?,
+        forceRefresh: Boolean,
+    ): List<JimakuFile> {
+        var files = getFilesOrFetch(
+            cacheKey = fileListCacheKey(entryId, episodeNumber),
+            forceRefresh = forceRefresh,
+        ) {
+            jimakuApi.getSubtitleFiles(entryId, episodeNumber)
+        }
+
+        if (files.isEmpty() && episodeNumber != null) {
+            files = getFilesOrFetch(
+                cacheKey = fileListCacheKey(entryId, null),
+                forceRefresh = forceRefresh,
+            ) {
+                jimakuApi.getSubtitleFiles(entryId, null)
+            }
+            _jimakuIsAllFiles.update { true }
+        } else {
+            _jimakuIsAllFiles.update { false }
+        }
+
+        return files
+    }
+
+    suspend fun fetchJimakuSubtitles(forceRefresh: Boolean = false): List<JimakuFile> {
+        jimakuSearchJob?.cancel()
+        if (!subtitlePreferences.jimakuEnabled().get()) return emptyList()
+
+        val jimakuApi = getJimakuApi() ?: return emptyList()
+        val episodeNumber = currentEpisode.value?.episode_number?.toInt()
+
+        _jimakuLoading.update { true }
+        _jimakuError.update { null }
+
+        return try {
+            val entries = resolveJimakuEntries(jimakuApi, forceRefresh)
+            _jimakuEntries.update { entries }
+
+            if (entries.isEmpty()) {
+                _jimakuFiles.update { emptyList() }
+                _jimakuError.update { JimakuUiError.NotFound }
+                return emptyList()
+            }
+
+            val files = fetchFilesForEntry(jimakuApi, entries.first().id, episodeNumber, forceRefresh)
+            _jimakuFiles.update { files }
+            files
+        } catch (e: JimakuAuthException) {
+            _jimakuError.update { JimakuUiError.AuthError }
+            emptyList()
+        } catch (e: JimakuRateLimitException) {
+            _jimakuError.update { JimakuUiError.RateLimited }
+            emptyList()
+        } catch (e: JimakuNetworkException) {
+            _jimakuError.update { JimakuUiError.NetworkError }
+            emptyList()
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR) { "Jimaku fetch failed: ${e.message}" }
+            _jimakuError.update { JimakuUiError.Unknown(e.message ?: "Unknown error") }
+            emptyList()
+        } finally {
+            _jimakuLoading.update { false }
+        }
+    }
+
+    fun searchJimakuByQuery(query: String) {
+        if (query.isBlank()) return
+        jimakuSearchJob?.cancel()
+        jimakuSearchJob = viewModelScope.launch {
+            _jimakuLoading.update { true }
+            _jimakuError.update { null }
+            try {
+                val jimakuApi = getJimakuApi() ?: return@launch
+                val episodeNumber = currentEpisode.value?.episode_number?.toInt()
+
+                val entries = getEntriesOrFetch(
+                    cacheKey = entrySearchCacheKey(query),
+                    forceRefresh = false,
+                ) {
+                    jimakuApi.searchByName(query)
+                }
+
+                _jimakuEntries.update { entries }
+
+                if (entries.isEmpty()) {
+                    _jimakuFiles.update { emptyList() }
+                    _jimakuError.update { JimakuUiError.NotFound }
+                    return@launch
+                }
+
+                val files = fetchFilesForEntry(jimakuApi, entries.first().id, episodeNumber, forceRefresh = false)
+                _jimakuFiles.update { files }
+            } catch (e: JimakuAuthException) {
+                _jimakuError.update { JimakuUiError.AuthError }
+            } catch (e: JimakuRateLimitException) {
+                _jimakuError.update { JimakuUiError.RateLimited }
+            } catch (e: JimakuNetworkException) {
+                _jimakuError.update { JimakuUiError.NetworkError }
+            } catch (e: Exception) {
+                _jimakuError.update { JimakuUiError.Unknown(e.message ?: "Unknown error") }
+            } finally {
+                _jimakuLoading.update { false }
+            }
+        }
+    }
+
+    fun addJimakuSubtitle(file: JimakuFile) {
+        viewModelScope.launch {
+            try {
+                val cachedFile = jimakuCachedFiles[file.url]
+                val localFile = if (cachedFile != null && cachedFile.exists()) {
+                    cachedFile
+                } else {
+                    val jimakuApi = getJimakuApi() ?: return@launch
+                    jimakuApi.downloadSubtitleToCache(file.url, file.name)?.also {
+                        jimakuCachedFiles[file.url] = it
+                    }
+                }
+                if (localFile != null) {
+                    MPVLib.command(arrayOf("sub-add", localFile.absolutePath, "select", file.name))
+                    _jimakuSelectedUrl.update { file.url }
+                    _jimakuAddedUrls.update { it + file.url }
+                    loadTracks()
+                }
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR) { "Jimaku subtitle add failed: ${e.message}" }
+            }
+        }
+    }
+
+    fun autoSelectBestJimakuSubtitle(files: List<JimakuFile>) {
+        val ranked = files.sortedWith(
+            compareByDescending<JimakuFile> { rankFileFormat(it.name) }
+                .thenByDescending { it.size }
+                .thenByDescending { it.lastModified ?: "" },
+        )
+        val best = ranked.firstOrNull() ?: return
+        addJimakuSubtitle(best)
     }
 
     val introSkipEnabled = playerPreferences.enableSkipIntro().get()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -77,6 +77,8 @@ import eu.kanade.tachiyomi.ui.player.settings.AudioPreferences
 import eu.kanade.tachiyomi.ui.player.settings.GesturePreferences
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
 import eu.kanade.tachiyomi.ui.player.settings.SubtitlePreferences
+import eu.kanade.tachiyomi.ui.player.utils.JimakuCallbacks
+import eu.kanade.tachiyomi.ui.player.utils.JimakuState
 import `is`.xyz.mpv.MPVLib
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
@@ -565,12 +567,31 @@ fun PlayerControls(
         val showFailedHosters by playerPreferences.showFailedHosters().collectAsState()
         val emptyHosters by playerPreferences.showEmptyHosters().collectAsState()
 
+        val jimakuState = JimakuState(
+            files = viewModel.jimakuFiles.collectAsState().value,
+            loading = viewModel.jimakuLoading.collectAsState().value,
+            error = viewModel.jimakuError.collectAsState().value,
+            addedUrls = viewModel.jimakuAddedUrls.collectAsState().value,
+            isAllFiles = viewModel.jimakuIsAllFiles.collectAsState().value,
+            enabled = subtitlePreferences.jimakuEnabled().collectAsState().value,
+        )
+
+        val jimakuCallbacks = remember {
+            JimakuCallbacks(
+                onFetch = viewModel::fetchJimakuFiles,
+                onSearch = viewModel::searchJimakuByQuery,
+                onAddSubtitle = viewModel::addJimakuSubtitle,
+            )
+        }
+
         PlayerSheets(
             sheetShown = sheetShown,
             subtitles = subtitles.toImmutableList(),
             selectedSubtitles = selectedSubtitles.toList().toImmutableList(),
             onAddSubtitle = viewModel::addSubtitle,
             onSelectSubtitle = viewModel::selectSub,
+            jimakuState = jimakuState,
+            jimakuCallbacks = jimakuCallbacks,
             audioTracks = audioTracks.toImmutableList(),
             selectedAudio = selectedAudio,
             onAddAudio = viewModel::addAudio,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerSheets.kt
@@ -34,6 +34,8 @@ import eu.kanade.tachiyomi.ui.player.controls.components.sheets.PlaybackSpeedShe
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.QualitySheet
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.ScreenshotSheet
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.SubtitlesSheet
+import eu.kanade.tachiyomi.ui.player.utils.JimakuCallbacks
+import eu.kanade.tachiyomi.ui.player.utils.JimakuState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import tachiyomi.domain.custombuttons.model.CustomButton
@@ -48,6 +50,10 @@ fun PlayerSheets(
     selectedSubtitles: ImmutableList<Int>,
     onAddSubtitle: (Uri) -> Unit,
     onSelectSubtitle: (Int) -> Unit,
+
+    // jimaku
+    jimakuState: JimakuState,
+    jimakuCallbacks: JimakuCallbacks,
 
     // audio sheet
     audioTracks: ImmutableList<VideoTrack>,
@@ -113,6 +119,8 @@ fun PlayerSheets(
                 onOpenSubtitleSettings = { onOpenPanel(Panels.SubtitleSettings) },
                 onOpenSubtitleDelay = { onOpenPanel(Panels.SubtitleDelay) },
                 onDismissRequest = onDismissRequest,
+                jimakuState = jimakuState,
+                jimakuCallbacks = jimakuCallbacks,
             )
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/SubtitleTracksSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/SubtitleTracksSheet.kt
@@ -23,22 +23,47 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MoreTime
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Subtitles
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.player.components.PlayerSheet
 import eu.kanade.tachiyomi.ui.player.PlayerViewModel.VideoTrack
+import eu.kanade.tachiyomi.ui.player.utils.JimakuCallbacks
+import eu.kanade.tachiyomi.ui.player.utils.JimakuFile
+import eu.kanade.tachiyomi.ui.player.utils.JimakuState
+import eu.kanade.tachiyomi.ui.player.utils.JimakuUiError
 import kotlinx.collections.immutable.ImmutableList
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.padding
@@ -53,60 +78,211 @@ fun SubtitlesSheet(
     onOpenSubtitleSettings: () -> Unit,
     onOpenSubtitleDelay: () -> Unit,
     onDismissRequest: () -> Unit,
+    jimakuState: JimakuState,
+    jimakuCallbacks: JimakuCallbacks,
     modifier: Modifier = Modifier,
 ) {
-    GenericTracksSheet(
-        tracks = tracks,
-        onDismissRequest = onDismissRequest,
-        header = {
-            TrackSheetTitle(
-                title = stringResource(MR.strings.pref_player_subtitle),
-                actions = {
-                    TextButton(onClick = onOpenSubtitleSettings) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
-                        ) {
-                            Icon(imageVector = Icons.Default.Palette, contentDescription = null)
-                            Text(text = stringResource(MR.strings.player_sheets_track_palette))
-                        }
+    var showJimakuDialog by remember { mutableStateOf(false) }
+
+    PlayerSheet(onDismissRequest) {
+        Column(modifier) {
+            LazyColumn {
+                item {
+                    TrackSheetTitle(
+                        title = stringResource(MR.strings.pref_player_subtitle),
+                        actions = {
+                            TextButton(onClick = onOpenSubtitleSettings) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+                                ) {
+                                    Icon(imageVector = Icons.Default.Palette, contentDescription = null)
+                                    Text(text = stringResource(MR.strings.player_sheets_track_palette))
+                                }
+                            }
+                            TextButton(onClick = onOpenSubtitleDelay) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+                                ) {
+                                    Icon(imageVector = Icons.Default.MoreTime, contentDescription = null)
+                                    Text(text = stringResource(MR.strings.player_sheets_track_delay))
+                                }
+                            }
+                        },
+                    )
+                }
+                item {
+                    AddTrackRow(
+                        title = stringResource(MR.strings.player_sheets_add_ext_sub),
+                        onClick = onAddSubtitle,
+                    )
+                }
+                if (jimakuState.enabled) {
+                    item {
+                        AddTrackRow(
+                            title = stringResource(MR.strings.player_jimaku_download_external),
+                            onClick = { showJimakuDialog = true },
+                        )
                     }
-                    TextButton(onClick = onOpenSubtitleDelay) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
-                        ) {
-                            Icon(imageVector = Icons.Default.MoreTime, contentDescription = null)
-                            Text(text = stringResource(MR.strings.player_sheets_track_delay))
-                        }
+                }
+                items(tracks) { track ->
+                    SubtitleTrackRow(
+                        title = getTrackTitle(track),
+                        selected = selectedTracks.indexOf(track.id),
+                        onClick = { onSelect(track.id) },
+                    )
+                }
+                item {
+                    Column(
+                        modifier = Modifier
+                            .padding(MaterialTheme.padding.medium)
+                            .fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.medium),
+                        horizontalAlignment = Alignment.Start,
+                    ) {
+                        Icon(Icons.Outlined.Info, null)
+                        Text(stringResource(MR.strings.player_sheets_subtitles_footer_secondary_sid_no_styles))
                     }
-                },
-            )
-            AddTrackRow(
-                title = stringResource(MR.strings.player_sheets_add_ext_sub),
-                onClick = onAddSubtitle,
-            )
-        },
-        track = { track ->
-            SubtitleTrackRow(
-                title = getTrackTitle(track),
-                selected = selectedTracks.indexOf(track.id),
-                onClick = { onSelect(track.id) },
-            )
-        },
-        footer = {
+                }
+            }
+        }
+    }
+
+    if (showJimakuDialog) {
+        JimakuDialog(
+            files = jimakuState.files,
+            loading = jimakuState.loading,
+            error = jimakuState.error,
+            addedUrls = jimakuState.addedUrls,
+            isAllFiles = jimakuState.isAllFiles,
+            onFetch = jimakuCallbacks.onFetch,
+            onSearch = jimakuCallbacks.onSearch,
+            onAddFile = jimakuCallbacks.onAddSubtitle,
+            onDismiss = { showJimakuDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun JimakuDialog(
+    files: List<JimakuFile>,
+    loading: Boolean,
+    error: JimakuUiError?,
+    addedUrls: Set<String>,
+    isAllFiles: Boolean,
+    onFetch: (forceRefresh: Boolean) -> Unit,
+    onSearch: (String) -> Unit,
+    onAddFile: (JimakuFile) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    LaunchedEffect(Unit) {
+        if (files.isEmpty()) onFetch(false)
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(MR.strings.pref_jimaku_group)) },
+        text = {
             Column(
-                modifier = modifier
-                    .padding(MaterialTheme.padding.medium)
-                    .fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.medium),
-                horizontalAlignment = Alignment.Start,
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
             ) {
-                Icon(Icons.Outlined.Info, null)
-                Text(stringResource(MR.strings.player_sheets_subtitles_footer_secondary_sid_no_styles))
+                if (loading) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(MaterialTheme.padding.medium),
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    }
+                }
+                if (error != null) {
+                    val errorText = when (error) {
+                        is JimakuUiError.AuthError -> stringResource(MR.strings.player_jimaku_error_auth)
+                        is JimakuUiError.RateLimited -> stringResource(MR.strings.player_jimaku_error_rate_limit)
+                        is JimakuUiError.NetworkError -> stringResource(MR.strings.player_jimaku_error_network)
+                        is JimakuUiError.NotFound -> stringResource(MR.strings.player_jimaku_no_results)
+                        is JimakuUiError.Unknown -> error.message
+                    }
+                    Text(
+                        text = errorText,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                var searchQuery by remember { mutableStateOf("") }
+
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    label = { Text(stringResource(MR.strings.player_jimaku_search_hint)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(
+                        onSearch = {
+                            if (searchQuery.isNotBlank()) onSearch(searchQuery)
+                        },
+                    ),
+                    trailingIcon = {
+                        if (searchQuery.isNotEmpty()) {
+                            IconButton(onClick = { searchQuery = "" }) {
+                                Icon(Icons.Default.Close, contentDescription = null)
+                            }
+                        }
+                    },
+                    enabled = !loading,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (isAllFiles && files.isNotEmpty()) {
+                    Text(
+                        text = stringResource(MR.strings.player_jimaku_showing_all_files),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                val sortedFiles = remember(files) { files.sortedBy { it.name.lowercase() } }
+                LazyColumn(modifier = Modifier.heightIn(max = 240.dp)) {
+                    items(sortedFiles, key = { it.url }) { file ->
+                        val isAdded = file.url in addedUrls
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    if (!isAdded) onAddFile(file)
+                                }
+                                .padding(vertical = MaterialTheme.padding.small),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+                        ) {
+                            Icon(
+                                imageVector = if (isAdded) Icons.Default.Check else Icons.Default.Subtitles,
+                                contentDescription = null,
+                            )
+                            Text(
+                                text = file.name,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = if (isAdded) FontWeight.Bold else FontWeight.Normal,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    }
+                }
             }
         },
-        modifier = modifier,
+        confirmButton = {
+            if (!loading && files.isNotEmpty()) {
+                TextButton(onClick = { onFetch(true) }) {
+                    Text(stringResource(MR.strings.player_jimaku_refresh))
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(MR.strings.action_close))
+            }
+        },
     )
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferences.kt
@@ -51,6 +51,14 @@ class SubtitlePreferences(
     fun subtitlesDelay() = preferenceStore.getInt("pref_subtitles_delay", 0)
     fun subtitlesSpeed() = preferenceStore.getFloat("pref_subtitles_speed", 1f)
     fun subtitlesSecondaryDelay() = preferenceStore.getInt("pref_subtitles_secondary_delay", 0)
+
+    // Jimaku
+    fun jimakuEnabled() = preferenceStore.getBoolean("pref_jimaku_enabled", false)
+    fun jimakuApiKey() = preferenceStore.getString(
+        tachiyomi.core.common.preference.Preference.privateKey("pref_jimaku_api_key"),
+        "",
+    )
+    fun jimakuAutoFetch() = preferenceStore.getBoolean("pref_jimaku_auto_fetch", true)
 }
 
 enum class SubtitleJustification(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/JimakuApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/JimakuApi.kt
@@ -1,0 +1,209 @@
+package eu.kanade.tachiyomi.ui.player.utils
+
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.jsonMime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import logcat.LogPriority
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import tachiyomi.core.common.util.system.logcat
+import uy.kohesive.injekt.injectLazy
+import java.io.File
+import java.io.IOException
+
+class JimakuApi(private val apiKey: String, private val cacheDir: File, private val client: OkHttpClient) {
+    private val json: Json by injectLazy()
+
+    private suspend fun <T> retryApiCall(url: String, onSuccess: (okhttp3.Response) -> T, defaultValue: T): T {
+        var last429Attempt = -1
+        var lastIOException: IOException? = null
+        repeat(3) { attempt ->
+            try {
+                val response = withContext(Dispatchers.IO) {
+                    client.newCall(
+                        GET(
+                            url,
+                            headers = Headers.Builder()
+                                .add("Authorization", apiKey)
+                                .build(),
+                        ),
+                    ).execute()
+                }
+
+                when (response.code) {
+                    200 -> return onSuccess(response)
+                    401 -> throw JimakuAuthException("Unauthorized: Invalid API key")
+                    429 -> {
+                        last429Attempt = attempt
+                        delay(2000)
+                    }
+                    else -> {
+                        logcat(LogPriority.WARN) { "Unexpected status ${response.code} for request" }
+                        return defaultValue
+                    }
+                }
+            } catch (e: JimakuAuthException) {
+                throw e
+            } catch (e: IOException) {
+                lastIOException = e
+                logcat(LogPriority.WARN, e) { "Network error on attempt ${attempt + 1}" }
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Retry attempt ${attempt + 1} failed" }
+            }
+        }
+        if (last429Attempt >= 0) {
+            throw JimakuRateLimitException("Rate limited")
+        }
+        lastIOException?.let { e ->
+            val networkErrorMessage = when {
+                url.contains("/api/entries/search") -> "Network error during search request"
+                url.contains("/api/entries/") && url.contains("/files") -> "Network error during files request"
+                else -> "Network error during download request"
+            }
+            throw JimakuNetworkException(networkErrorMessage, e)
+        }
+        return defaultValue
+    }
+
+    private suspend fun retrySearchRequest(url: String): List<JimakuEntry> {
+        return retryApiCall(
+            url = url,
+            onSuccess = { response ->
+                json.decodeFromString<List<JimakuEntry>>(response.body.string())
+            },
+            defaultValue = emptyList(),
+        )
+    }
+
+    suspend fun searchByAniListId(aniListId: Long): List<JimakuEntry> {
+        val url = "https://jimaku.cc/api/entries/search?anilist_id=$aniListId"
+        return retrySearchRequest(url)
+    }
+
+    suspend fun searchByName(name: String): List<JimakuEntry> {
+        val encodedName = java.net.URLEncoder.encode(name, "UTF-8")
+        val url = "https://jimaku.cc/api/entries/search?query=$encodedName"
+        return retrySearchRequest(url)
+    }
+
+    suspend fun getAniListIdFromMal(idMal: Long): Long {
+        return withContext(Dispatchers.IO) {
+            val query = """
+                 query {
+                     Media(idMal:$idMal,type: ANIME) {
+                         id
+                     }
+                 }
+            """.trimMargin()
+
+            val response = try {
+                client.newCall(
+                    POST(
+                        "https://graphql.anilist.co",
+                        body = buildJsonObject { put("query", query) }.toString()
+                            .toRequestBody(jsonMime),
+                    ),
+                ).execute()
+            } catch (e: Exception) {
+                return@withContext 0L
+            }
+            val body = response.body.string()
+            return@withContext try {
+                json.parseToJsonElement(body)
+                    .jsonObject["data"]
+                    ?.jsonObject?.get("Media")
+                    ?.jsonObject?.get("id")
+                    ?.jsonPrimitive?.longOrNull ?: 0L
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to parse AniList ID from MAL response" }
+                0L
+            }
+        }
+    }
+
+    suspend fun getSubtitleFiles(entryId: Long, episode: Int? = null): List<JimakuFile> {
+        val episodeParam = if (episode != null) "?episode=$episode" else ""
+        val url = "https://jimaku.cc/api/entries/$entryId/files$episodeParam"
+        return retryFilesRequest(url)
+    }
+
+    private suspend fun retryFilesRequest(url: String): List<JimakuFile> {
+        return retryApiCall(
+            url = url,
+            onSuccess = { response ->
+                json.decodeFromString<List<JimakuFile>>(response.body.string()).filter { file ->
+                    val name = file.name.lowercase()
+                    !name.endsWith(".zip") && !name.endsWith(".rar") && !name.endsWith(".7z")
+                }
+            },
+            defaultValue = emptyList(),
+        )
+    }
+
+    suspend fun downloadSubtitleToCache(fileUrl: String, fileName: String): File? {
+        return retryDownloadRequest(fileUrl, fileName)
+    }
+
+    private suspend fun retryDownloadRequest(fileUrl: String, fileName: String): File? {
+        return retryApiCall(
+            url = fileUrl,
+            onSuccess = { response ->
+                File(cacheDir, fileName).apply {
+                    writeBytes(response.body.bytes())
+                }
+            },
+            defaultValue = null,
+        )
+    }
+}
+
+class JimakuAuthException(message: String) : Exception(message)
+class JimakuRateLimitException(message: String) : Exception(message)
+class JimakuNetworkException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+@Serializable
+data class JimakuEntry(
+    val id: Long,
+    val name: String,
+    @SerialName("english_name")
+    val englishName: String? = null,
+    @SerialName("japanese_name")
+    val japaneseName: String? = null,
+    @SerialName("anilist_id")
+    val anilistId: Int? = null,
+    @SerialName("tmdb_id")
+    val tmdbId: String? = null,
+    val flags: JimakuFlags? = null,
+    @SerialName("last_modified")
+    val lastModified: String? = null,
+)
+
+@Serializable
+data class JimakuFlags(
+    val anime: Boolean = false,
+    val movie: Boolean = false,
+    val adult: Boolean = false,
+    val unverified: Boolean = false,
+    val external: Boolean = false,
+)
+
+@Serializable
+data class JimakuFile(
+    val url: String,
+    val name: String,
+    val size: Long,
+    @SerialName("last_modified")
+    val lastModified: String? = null,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/JimakuHelpers.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/utils/JimakuHelpers.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.ui.player.utils
+
+sealed interface JimakuUiError {
+    data object AuthError : JimakuUiError
+    data object RateLimited : JimakuUiError
+    data object NetworkError : JimakuUiError
+    data object NotFound : JimakuUiError
+    data class Unknown(val message: String) : JimakuUiError
+}
+
+internal fun rankFileFormat(filename: String): Int {
+    val lower = filename.lowercase()
+    return when {
+        lower.endsWith(".ass") -> 3
+        lower.endsWith(".ssa") -> 2
+        lower.endsWith(".srt") -> 1
+        else -> 0
+    }
+}
+
+internal fun entrySearchCacheKey(query: String): String = "query:${query.lowercase().trim()}"
+internal fun entryIdCacheKey(anilistId: Long): String = "anilist:$anilistId"
+internal fun fileListCacheKey(entryId: Long, episode: Int?): String = "$entryId:${episode ?: "all"}"
+
+data class JimakuState(
+    val files: List<JimakuFile> = emptyList(),
+    val loading: Boolean = false,
+    val error: JimakuUiError? = null,
+    val addedUrls: Set<String> = emptySet(),
+    val isAllFiles: Boolean = false,
+    val enabled: Boolean = false,
+)
+
+data class JimakuCallbacks(
+    val onFetch: (forceRefresh: Boolean) -> Unit,
+    val onSearch: (String) -> Unit,
+    val onAddSubtitle: (JimakuFile) -> Unit,
+)

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/player/JimakuHelpersTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/player/JimakuHelpersTest.kt
@@ -1,0 +1,222 @@
+package eu.kanade.tachiyomi.ui.player
+
+import eu.kanade.tachiyomi.ui.player.utils.JimakuFile
+import eu.kanade.tachiyomi.ui.player.utils.JimakuUiError
+import eu.kanade.tachiyomi.ui.player.utils.entryIdCacheKey
+import eu.kanade.tachiyomi.ui.player.utils.entrySearchCacheKey
+import eu.kanade.tachiyomi.ui.player.utils.fileListCacheKey
+import eu.kanade.tachiyomi.ui.player.utils.rankFileFormat
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class JimakuHelpersTest {
+
+    // Tests for rankFileFormat() — 7 test cases
+
+    @Test
+    fun testRankFileFormat_Ass() {
+        val result = rankFileFormat("subtitle.ass")
+        result shouldBe 3
+    }
+
+    @Test
+    fun testRankFileFormat_AssCaseInsensitive() {
+        val resultUpper = rankFileFormat("subtitle.ASS")
+        val resultMixed = rankFileFormat("subtitle.Ass")
+        resultUpper shouldBe 3
+        resultMixed shouldBe 3
+    }
+
+    @Test
+    fun testRankFileFormat_Ssa() {
+        val result = rankFileFormat("subtitle.ssa")
+        result shouldBe 2
+    }
+
+    @Test
+    fun testRankFileFormat_SsaCaseInsensitive() {
+        val result = rankFileFormat("subtitle.SSA")
+        result shouldBe 2
+    }
+
+    @Test
+    fun testRankFileFormat_Srt() {
+        val result = rankFileFormat("subtitle.srt")
+        result shouldBe 1
+    }
+
+    @Test
+    fun testRankFileFormat_Vtt() {
+        val result = rankFileFormat("subtitle.vtt")
+        result shouldBe 0
+    }
+
+    @Test
+    fun testRankFileFormat_NoExtension() {
+        val result = rankFileFormat("subtitle")
+        result shouldBe 0
+    }
+
+    // Tests for ranking/sorting logic — 4 test cases
+
+    @Test
+    fun testRanking_MixedFormats() {
+        val files = listOf(
+            JimakuFile(
+                url = "https://example.com/sub1.srt",
+                name = "subtitle.srt",
+                size = 50000L,
+                lastModified = "2024-01-01T00:00:00Z",
+            ),
+            JimakuFile(
+                url = "https://example.com/sub2.ass",
+                name = "subtitle.ass",
+                size = 30000L,
+                lastModified = "2024-01-01T00:00:00Z",
+            ),
+            JimakuFile(
+                url = "https://example.com/sub3.txt",
+                name = "subtitle.txt",
+                size = 40000L,
+                lastModified = "2024-01-01T00:00:00Z",
+            ),
+        )
+
+        val ranked = files.sortedWith(
+            compareByDescending<JimakuFile> { rankFileFormat(it.name) }
+                .thenByDescending { it.size }
+                .thenByDescending { it.lastModified.orEmpty() },
+        )
+
+        ranked.first().name shouldBe "subtitle.ass"
+    }
+
+    @Test
+    fun testRanking_SameFormat_DifferentSizes() {
+        val files = listOf(
+            JimakuFile(
+                url = "https://example.com/sub1.ass",
+                name = "subtitle1.ass",
+                size = 100000L,
+                lastModified = "2024-01-01T00:00:00Z",
+            ),
+            JimakuFile(
+                url = "https://example.com/sub2.ass",
+                name = "subtitle2.ass",
+                size = 200000L,
+                lastModified = "2024-01-01T00:00:00Z",
+            ),
+        )
+
+        val ranked = files.sortedWith(
+            compareByDescending<JimakuFile> { rankFileFormat(it.name) }
+                .thenByDescending { it.size }
+                .thenByDescending { it.lastModified.orEmpty() },
+        )
+
+        ranked.first().size shouldBe 200000L
+    }
+
+    @Test
+    fun testRanking_SameFormatAndSize_DifferentTimestamps() {
+        val files = listOf(
+            JimakuFile(
+                url = "https://example.com/sub1.ass",
+                name = "subtitle1.ass",
+                size = 100000L,
+                lastModified = "2024-01-01T00:00:00Z",
+            ),
+            JimakuFile(
+                url = "https://example.com/sub2.ass",
+                name = "subtitle2.ass",
+                size = 100000L,
+                lastModified = "2024-02-01T00:00:00Z",
+            ),
+        )
+
+        val ranked = files.sortedWith(
+            compareByDescending<JimakuFile> { rankFileFormat(it.name) }
+                .thenByDescending { it.size }
+                .thenByDescending { it.lastModified.orEmpty() },
+        )
+
+        ranked.first().lastModified shouldBe "2024-02-01T00:00:00Z"
+    }
+
+    @Test
+    fun testRanking_EmptyList() {
+        val files = emptyList<JimakuFile>()
+        val ranked = files.sortedWith(
+            compareByDescending<JimakuFile> { rankFileFormat(it.name) }
+                .thenByDescending { it.size }
+                .thenByDescending { it.lastModified.orEmpty() },
+        )
+
+        ranked.firstOrNull().shouldBeNull()
+    }
+
+    // Tests for entrySearchCacheKey() — 3 test cases
+
+    @Test
+    fun testEntrySearchCacheKey_BasicLowercasing() {
+        val result = entrySearchCacheKey("Frieren")
+        result shouldBe "query:frieren"
+    }
+
+    @Test
+    fun testEntrySearchCacheKey_TrimAndLowercase() {
+        val result = entrySearchCacheKey("  Frieren  ")
+        result shouldBe "query:frieren"
+    }
+
+    @Test
+    fun testEntrySearchCacheKey_MultipleWords() {
+        val result = entrySearchCacheKey("BOCCHI THE ROCK")
+        result shouldBe "query:bocchi the rock"
+    }
+
+    @Test
+    fun testEntrySearchCacheKey_EmptyString() {
+        val result = entrySearchCacheKey("")
+        result shouldBe "query:"
+    }
+
+    // Tests for entryIdCacheKey() — 1 test case
+
+    @Test
+    fun testEntryIdCacheKey_LongId() {
+        val result = entryIdCacheKey(154587L)
+        result shouldBe "anilist:154587"
+    }
+
+    // Tests for fileListCacheKey() — 2 test cases
+
+    @Test
+    fun testFileListCacheKey_WithEpisodeNumber() {
+        val result = fileListCacheKey(12345L, 3)
+        result shouldBe "12345:3"
+    }
+
+    @Test
+    fun testFileListCacheKey_WithNullEpisode() {
+        val result = fileListCacheKey(12345L, null)
+        result shouldBe "12345:all"
+    }
+
+    // Tests for JimakuUiError sealed class — 2 test cases
+
+    @Test
+    fun testJimakuUiError_AuthErrorSingleton() {
+        val error1 = JimakuUiError.AuthError
+        val error2 = JimakuUiError.AuthError
+        (error1 === error2) shouldBe true
+    }
+
+    @Test
+    fun testJimakuUiError_UnknownWithMessage() {
+        val message = "Test error message"
+        val error = JimakuUiError.Unknown(message)
+        error.message shouldBe message
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -311,6 +311,22 @@
     <string name="pref_player_subtitle_blacklist">Blacklist</string>
     <string name="pref_player_subtitle_blacklist_info">Blacklist for subtitles. If a blacklist is defined, all subtitles that contains a blacklisted word will be filtered out. Multiple values can be delimited by a comma.</string>
 
+    <!-- Player settings - Jimaku -->
+    <string name="pref_jimaku_group">Jimaku</string>
+    <string name="pref_jimaku_enabled">Enable Jimaku subtitles</string>
+    <string name="pref_jimaku_enabled_summary">Fetch Japanese subtitles from jimaku.cc</string>
+    <string name="pref_jimaku_api_key">API key</string>
+    <string name="pref_jimaku_auto_fetch">Auto-fetch subtitles</string>
+    <string name="pref_jimaku_auto_fetch_summary">Automatically fetch subtitles when a video starts</string>
+    <string name="player_jimaku_download_external">Download from external sources</string>
+    <string name="player_jimaku_no_results">No subtitles found</string>
+    <string name="player_jimaku_refresh">Refresh</string>
+    <string name="player_jimaku_showing_all_files">No subtitles found for this episode. Showing all available files.</string>
+    <string name="player_jimaku_error_auth">Invalid API key. Check your Jimaku settings.</string>
+    <string name="player_jimaku_error_rate_limit">Rate limited by Jimaku. Please try again shortly.</string>
+    <string name="player_jimaku_error_network">Network error. Check your connection.</string>
+    <string name="player_jimaku_search_hint">Search anime on Jimaku…</string>
+
     <!-- Player settings - Audio -->
     <string name="pref_player_audio">Audio</string>
     <string name="pref_player_audio_summary">Preferred languages, pitch correction, audio channels</string>


### PR DESCRIPTION
This is an AI generated PR! I have tested the feature and can confirm that it's working.

Related issues: https://github.com/aniyomiorg/aniyomi/issues/441 https://github.com/aniyomiorg/aniyomi/issues/1946
I would work on opensubtitle and subdl support next.

Integrates [jimaku.cc](https://jimaku.cc) as a subtitle source in the player. You can search for Japanese subtitles by anime title, or let the player fetch them automatically when a video starts.

Settings live under Player > Subtitle: a toggle for Jimaku, an API key field, and an auto-fetch option. Search results and downloaded files are cached per-episode so the API isn't hit repeatedly. Errors (bad API key, rate limits, network failures) show as player messages.

New files:
- `JimakuApi.kt` - API client, caching, downloads, error types
- `JimakuHelpersTest.kt` - 20 unit tests

Changed files:
- `SubtitleTracksSheet.kt` - JimakuDialog composable, "Download from external sources" button
- `PlayerViewModel.kt` - search/download logic, auto-fetch on video load
- `PlayerActivity.kt`, `PlayerControls.kt`, `PlayerSheets.kt` - wiring
- `SubtitlePreferences.kt`, `PlayerSettingsSubtitleScreen.kt` - settings UI
- `strings.xml` - 16 new strings


### Images

| Settings | Subtitle sheet |
| ------- | ------- |
| <img width="240" alt="Jimaku settings page showing toggle, API key field, and auto-fetch option" src="https://github.com/user-attachments/assets/ff439d20-f0c3-4f23-b5b6-a3253bf41fb0" /> | <img width="400" alt="Subtitle sheet with auto-fetched Jimaku subtitle loaded over playing video" src="https://github.com/user-attachments/assets/60a40bbc-5411-4b9f-b969-47b82ee5605b" /> |

| Jimaku auto-fetch | Jimaku manual search |
| ------- | ------- |
| <img width="400" alt="JimakuDialog showing auto-fetched subtitle file with checkmark" src="https://github.com/user-attachments/assets/3b658ddb-b625-4729-b54e-f4542371a121" /> | <img width="400" alt="JimakuDialog showing Frieren search results from Jimaku" src="https://github.com/user-attachments/assets/84d3972d-0dbd-499e-a1f8-7df14bc3ff81" /> |

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/anikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Integrate Jimaku subtitle discovery and automatic selection into the player with configurable settings and cached downloads.

New Features:
- Add Jimaku as an external Japanese subtitle source with anime search, episode file retrieval, manual subtitle selection, and automatic subtitle fetching.
- Add player subtitle settings for enabling Jimaku, storing its API key, and configuring automatic fetching.

Enhancements:
- Cache Jimaku searches, file listings, and downloaded subtitle files to reduce repeated requests.
- Display actionable authentication, rate-limit, network, and missing-subtitle errors in the player.
- Prefer suitable subtitle formats when automatically selecting a Jimaku file.

Tests:
- Add unit coverage for Jimaku file ranking, cache keys, and UI error models.