### PR TITLE
Feature: Add AniList Schedule

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,10 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools" >
 
     <!-- Android TV -->
-   <uses-feature android:name="android.software.leanback" android:required="false" />
-   <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature android:name="android.software.leanback" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
-   <!-- Internet -->
+    <!-- Internet -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
@@ -21,6 +21,9 @@
     <!-- For background jobs -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- Lets the airing-schedule notification bell fire at the exact air time on Android 12+,
+         instead of being deferred by Doze/App Standby batching windows. -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
@@ -173,9 +176,9 @@
             android:exported="false"
             android:theme="@style/Theme.AppCompat.NoActionBar"
             android:launchMode="singleTask">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN"/>
-        </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+            </intent-filter>
         </activity>
 
 
@@ -201,6 +204,7 @@
         <activity
             android:name=".ui.setting.track.TrackLoginActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:label="@string/track_activity_name">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -261,6 +265,10 @@
 
         <receiver
             android:name=".data.notification.NotificationReceiver"
+            android:exported="false" />
+
+        <receiver
+            android:name="mihon.feature.airingschedule.notification.ScheduleAlarmReceiver"
             android:exported="false" />
 
         <service

--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -40,7 +40,7 @@ class UiPreferences(
 
     fun startScreen() = preferenceStore.getEnum("start_screen", StartScreen.ANIME)
 
-    fun navStyle() = preferenceStore.getEnum("bottom_rail_nav_style", NavStyle.MOVE_HISTORY_TO_MORE)
+    fun navStyle() = preferenceStore.getEnum("bottom_rail_nav_style", NavStyle.MOVE_SCHEDULE_TO_MORE)
 
     // SY -->
     fun bottomBarLabels() = preferenceStore.getBoolean("pref_show_bottom_bar_labels", true)

--- a/app/src/main/java/eu/kanade/domain/ui/model/NavStyle.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/model/NavStyle.kt
@@ -1,6 +1,7 @@
 package eu.kanade.domain.ui.model
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DateRange
 import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.runtime.Composable
@@ -14,6 +15,7 @@ import eu.kanade.tachiyomi.ui.history.HistoryTab
 import eu.kanade.tachiyomi.ui.library.LibraryTab
 import eu.kanade.tachiyomi.ui.more.MoreTab
 import eu.kanade.tachiyomi.ui.updates.UpdatesTab
+import mihon.feature.airingschedule.AiringScheduleTab
 import tachiyomi.i18n.MR
 
 enum class NavStyle(
@@ -23,6 +25,7 @@ enum class NavStyle(
     MOVE_UPDATES_TO_MORE(titleRes = MR.strings.pref_bottom_nav_no_updates, moreTab = UpdatesTab),
     MOVE_HISTORY_TO_MORE(titleRes = MR.strings.pref_bottom_nav_no_history, moreTab = HistoryTab),
     MOVE_BROWSE_TO_MORE(titleRes = MR.strings.pref_bottom_nav_no_browse, moreTab = BrowseTab),
+    MOVE_SCHEDULE_TO_MORE(titleRes = MR.strings.pref_bottom_nav_no_schedule, moreTab = AiringScheduleTab),
     ;
 
     val moreIcon: ImageVector
@@ -31,6 +34,7 @@ enum class NavStyle(
             MOVE_UPDATES_TO_MORE -> ImageVector.vectorResource(id = R.drawable.ic_updates_outline_24dp)
             MOVE_HISTORY_TO_MORE -> Icons.Outlined.History
             MOVE_BROWSE_TO_MORE -> Icons.Outlined.Explore
+            MOVE_SCHEDULE_TO_MORE -> Icons.Outlined.DateRange
         }
 
     val tabs: List<Tab>
@@ -39,6 +43,7 @@ enum class NavStyle(
                 LibraryTab,
                 UpdatesTab,
                 HistoryTab,
+                AiringScheduleTab,
                 BrowseTab,
                 MoreTab,
             ).apply { remove(this@NavStyle.moreTab) }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.CollectionsBookmark
 import androidx.compose.material.icons.outlined.Explore
@@ -229,6 +230,12 @@ object SettingsMainScreen : Screen() {
             subtitleRes = MR.strings.pref_advanced_summary,
             icon = Icons.Outlined.Code,
             screen = SettingsAdvancedScreen,
+        ),
+        Item(
+            titleRes = MR.strings.pref_category_schedule,
+            subtitleRes = MR.strings.pref_category_schedule_summary,
+            icon = Icons.Outlined.CalendarMonth,
+            screen = SettingsScheduleScreen,
         ),
         Item(
             titleRes = MR.strings.pref_category_about,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsScheduleScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsScheduleScreen.kt
@@ -1,0 +1,194 @@
+package eu.kanade.presentation.more.settings.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import eu.kanade.presentation.more.settings.Preference
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableMap
+import mihon.feature.airingschedule.ScheduleDataRefreshWorker
+import mihon.feature.airingschedule.SchedulePreferences
+import mihon.feature.airingschedule.ScheduleRefreshWorker
+import mihon.feature.airingschedule.notification.ScheduleNotifications
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+object SettingsScheduleScreen : SearchableSettings {
+
+    @ReadOnlyComposable
+    @Composable
+    override fun getTitleRes() = MR.strings.pref_category_schedule
+
+    @Composable
+    override fun getPreferences(): List<Preference> {
+        val context = LocalContext.current
+        val schedulePreferences = remember { Injekt.get<SchedulePreferences>() }
+
+        val autoRefreshEnabledPref = schedulePreferences.scheduleAutoRefreshEnabled()
+        val autoRefreshEnabled by autoRefreshEnabledPref.changes().collectAsState(initial = autoRefreshEnabledPref.get())
+        val autoRefreshFrequencyPref = schedulePreferences.scheduleAutoRefreshFrequency()
+        val autoRefreshFrequency by autoRefreshFrequencyPref.changes().collectAsState(initial = autoRefreshFrequencyPref.get())
+
+        val uploadDelayEnabledPref = schedulePreferences.uploadDelayEnabled()
+        val uploadDelayEnabled by uploadDelayEnabledPref.changes().collectAsState(initial = uploadDelayEnabledPref.get())
+        val uploadDelayIntervalPref = schedulePreferences.uploadDelayRefreshInterval()
+        val uploadDelayInterval by uploadDelayIntervalPref.changes().collectAsState(initial = uploadDelayIntervalPref.get())
+
+        LaunchedEffect(autoRefreshEnabled, autoRefreshFrequency) {
+            if (autoRefreshEnabled) {
+                ScheduleDataRefreshWorker.schedule(context, autoRefreshFrequency)
+            } else {
+                ScheduleDataRefreshWorker.cancel(context)
+            }
+        }
+
+        LaunchedEffect(uploadDelayEnabled, uploadDelayInterval) {
+            if (uploadDelayEnabled) {
+                ScheduleRefreshWorker.schedule(context, uploadDelayInterval)
+            } else {
+                ScheduleRefreshWorker.cancel(context)
+            }
+        }
+
+        var exactAlarmsAllowed by remember { mutableStateOf(ScheduleNotifications.canScheduleExactAlarms(context)) }
+        LaunchedEffect(Unit) {
+            exactAlarmsAllowed = ScheduleNotifications.canScheduleExactAlarms(context)
+        }
+
+        val titleLanguageOptions = mapOf(
+            SchedulePreferences.TitleLanguage.USER_PREFERRED to "User Preferred (AniList default)",
+            SchedulePreferences.TitleLanguage.ENGLISH to "English",
+            SchedulePreferences.TitleLanguage.ROMAJI to "Romaji",
+            SchedulePreferences.TitleLanguage.NATIVE to "Native",
+        ).toImmutableMap()
+
+        val intervalOptions = mapOf(
+            SchedulePreferences.UploadDelayInterval.THIRTY_MIN to "Every 30 minutes",
+            SchedulePreferences.UploadDelayInterval.ONE_HOUR to "Every 1 hour",
+            SchedulePreferences.UploadDelayInterval.TWO_HOURS to "Every 2 hours",
+            SchedulePreferences.UploadDelayInterval.SIX_HOURS to "Every 6 hours",
+            SchedulePreferences.UploadDelayInterval.TWELVE_HOURS to "Every 12 hours",
+            SchedulePreferences.UploadDelayInterval.CUSTOM to "Custom delay (set your own minutes)",
+            SchedulePreferences.UploadDelayInterval.NEVER to "Never (manual only)",
+        ).toImmutableMap()
+
+        val autoRefreshFrequencyOptions = mapOf(
+            SchedulePreferences.AutoRefreshFrequency.EVERY_1_DAY to "Every 1 day",
+            SchedulePreferences.AutoRefreshFrequency.EVERY_2_DAYS to "Every 2 days",
+            SchedulePreferences.AutoRefreshFrequency.EVERY_3_DAYS to "Every 3 days",
+            SchedulePreferences.AutoRefreshFrequency.EVERY_4_DAYS to "Every 4 days",
+            SchedulePreferences.AutoRefreshFrequency.EVERY_5_DAYS to "Every 5 days",
+            SchedulePreferences.AutoRefreshFrequency.EVERY_6_DAYS to "Every 6 days",
+            SchedulePreferences.AutoRefreshFrequency.EVERY_7_DAYS to "Every 7 days",
+        ).toImmutableMap()
+
+        val dataSourceOptions = mapOf(
+            SchedulePreferences.ScheduleDataSource.ANILIST to "AniList (Global)",
+            SchedulePreferences.ScheduleDataSource.SMART_UPDATES to "Smart Updates (Library)",
+        ).toImmutableMap()
+
+        return listOf(
+            Preference.PreferenceGroup(
+                title = "General",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.ListPreference(
+                        pref = schedulePreferences.scheduleDataSource(),
+                        title = "Default schedule view",
+                        subtitle = "Select which data source to show by default in the schedule hub",
+                        entries = dataSourceOptions,
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_schedule_auto_refresh_group),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.SwitchPreference(
+                        pref = schedulePreferences.scheduleAutoRefreshEnabled(),
+                        title = "Auto-refresh schedule",
+                        subtitle = "Automatically refresh the weekly airing schedule in the background",
+                    ),
+                    Preference.PreferenceItem.ListPreference(
+                        pref = schedulePreferences.scheduleAutoRefreshFrequency(),
+                        title = "Refresh frequency",
+                        subtitle = "How often to refresh the schedule (1–7 days). Default: every 7 days",
+                        entries = autoRefreshFrequencyOptions,
+                        enabled = autoRefreshEnabled,
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_schedule_upload_delay_group),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.SwitchPreference(
+                        pref = schedulePreferences.uploadDelayEnabled(),
+                        title = "Auto-sync source upload time",
+                        subtitle = "Checks your pinned sources' real episode lists against AniList's air time to learn their upload delay. Uses priority order (1st pinned source takes precedence).",
+                    ),
+                    Preference.PreferenceItem.ListPreference(
+                        pref = schedulePreferences.uploadDelayRefreshInterval(),
+                        title = "Refresh interval",
+                        subtitle = "How often to re-check and continuously refine the learned upload delay per source using a running average",
+                        entries = intervalOptions,
+                        enabled = uploadDelayEnabled,
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        pref = schedulePreferences.customUploadDelayMinutes(),
+                        title = "Custom delay (minutes)",
+                        subtitle = "Only used when Refresh interval is set to Custom. A fixed number of minutes added to the official air time — shifts the expected upload time and countdown shown for every episode, in place of the auto-learned delay. Negative values mean early.",
+                        enabled = uploadDelayEnabled && uploadDelayInterval == SchedulePreferences.UploadDelayInterval.CUSTOM,
+                        onValueChanged = { it.trim().toLongOrNull()?.let { minutes -> minutes in -24 * 60..24 * 60 } ?: false },
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
+                title = "Notifications",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.InfoPreference(
+                        title = if (exactAlarmsAllowed) {
+                            "Exact alarm permission is granted — the notification bell will fire at the precise air time, even in the background with battery optimization enabled."
+                        } else {
+                            "Exact alarm permission is not granted. On Android 13+, the notification bell may fire late without it. Tap Settings → Apps → Anikku Modified → Alarms & reminders to allow it, or tap below."
+                        },
+                    ),
+                    Preference.PreferenceItem.TextPreference(
+                        title = "Grant exact alarm permission",
+                        subtitle = if (exactAlarmsAllowed) "Already granted" else "Required for reliable on-time episode alerts",
+                        onClick = { ScheduleNotifications.requestExactAlarmPermission(context) },
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_schedule_display_group),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.ListPreference(
+                        pref = schedulePreferences.titleLanguage(),
+                        title = "Preferred title language",
+                        subtitle = "Language used to display anime titles in the schedule",
+                        entries = titleLanguageOptions,
+                    ),
+                    Preference.PreferenceItem.SwitchPreference(
+                        pref = schedulePreferences.showAdultContent(),
+                        title = "Show 18+ anime",
+                        subtitle = "Include adult-only anime in the airing schedule",
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_schedule_about_title),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.InfoPreference(
+                        title = "The airing schedule is powered by AniList. Upload delay tracking monitors when episodes appear on your pinned sources vs the official air time — uses priority order (1st pinned source takes precedence). Tap the play or search icon on any anime to find it in All sources. Tap the bookmark icon to add it to your library.",
+                    ),
+                ),
+            ),
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -102,6 +102,12 @@ object Notifications {
     const val ID_UPDATES_TO_EXTS = -401
     const val ID_EXTENSION_INSTALLER = -402
 
+    /**
+     * Notification channel used for airing schedule episode alerts.
+     */
+    const val CHANNEL_AIRING_SCHEDULE = "airing_schedule_channel"
+    const val ID_AIRING_SCHEDULE_BASE = -1801
+
     private val deprecatedChannels = listOf(
         "downloader_channel",
         "downloader_complete_channel",
@@ -201,6 +207,9 @@ object Notifications {
                 buildNotificationChannel(CHANNEL_EXTENSIONS_UPDATE, IMPORTANCE_DEFAULT) {
                     setGroup(GROUP_APK_UPDATES)
                     setName(context.stringResource(MR.strings.channel_ext_updates))
+                },
+                buildNotificationChannel(CHANNEL_AIRING_SCHEDULE, IMPORTANCE_HIGH) {
+                    setName("Airing schedule alerts")
                 },
             ),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -20,6 +20,8 @@ import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
 import eu.kanade.tachiyomi.ui.player.settings.SubtitlePreferences
 import eu.kanade.tachiyomi.util.LocalHttpServerHolder
 import eu.kanade.tachiyomi.util.system.isDebugBuildType
+import mihon.feature.airingschedule.SchedulePreferences
+import mihon.feature.airingschedule.UploadDelayTracker
 import tachiyomi.core.common.preference.AndroidPreferenceStore
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.storage.AndroidStorageFolderProvider
@@ -100,6 +102,9 @@ class PreferenceModule(val app: Application) : InjektModule {
         // AM (CONNECTIONS) -->
         addSingletonFactory { ConnectionsPreferences(get()) }
         // <-- AM (CONNECTIONS)
+
+        addSingletonFactory { SchedulePreferences(get()) }
+        addSingletonFactory { UploadDelayTracker() }
 
         addSingletonFactory {
             SyncPreferences(get())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -39,8 +39,12 @@ data object BrowseTab : Tab {
         get() {
             val isSelected = LocalTabNavigator.current.current is BrowseTab
             val image = AnimatedImageVector.animatedVectorResource(R.drawable.anim_browse_enter)
+            val index: UShort = when (currentNavigationStyle()) {
+                eu.kanade.domain.ui.model.NavStyle.MOVE_BROWSE_TO_MORE -> 5u
+                else -> 3u
+            }
             return TabOptions(
-                index = 3u,
+                index = index,
                 title = stringResource(MR.strings.browse),
                 icon = rememberAnimatedVectorPainter(image, isSelected),
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
@@ -20,6 +20,7 @@ import tachiyomi.presentation.core.screens.LoadingScreen
 class GlobalSearchScreen(
     val searchQuery: String = "",
     private val extensionFilter: String? = null,
+    private val initialSourceFilter: SourceFilter = SourceFilter.PinnedOnly,
 ) : Screen() {
 
     @Composable
@@ -35,6 +36,7 @@ class GlobalSearchScreen(
             GlobalSearchScreenModel(
                 initialQuery = searchQuery,
                 initialExtensionFilter = extensionFilter,
+                initialSourceFilter = initialSourceFilter,
             )
         }
         val state by screenModel.state.collectAsState()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
@@ -5,9 +5,11 @@ import eu.kanade.tachiyomi.source.CatalogueSource
 class GlobalSearchScreenModel(
     initialQuery: String = "",
     initialExtensionFilter: String? = null,
+    initialSourceFilter: SourceFilter = SourceFilter.PinnedOnly,
 ) : SearchScreenModel(
     State(
         searchQuery = initialQuery,
+        sourceFilter = initialSourceFilter,
     ),
 ) {
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -50,7 +50,7 @@ data object HistoryTab : Tab {
             val image = AnimatedImageVector.animatedVectorResource(R.drawable.anim_history_enter)
             val index: UShort = when (currentNavigationStyle()) {
                 NavStyle.MOVE_HISTORY_TO_MORE -> 5u
-                NavStyle.MOVE_BROWSE_TO_MORE -> 3u
+                NavStyle.MOVE_UPDATES_TO_MORE -> 1u
                 else -> 2u
             }
             return TabOptions(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
@@ -32,7 +32,6 @@ import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import mihon.feature.upcoming.UpcomingScreen
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.i18n.MR
@@ -47,10 +46,8 @@ data object UpdatesTab : Tab {
             val isSelected = LocalTabNavigator.current.current.key == key
             val image = AnimatedImageVector.animatedVectorResource(R.drawable.anim_updates_enter)
             val index: UShort = when (currentNavigationStyle()) {
-                NavStyle.MOVE_UPDATES_TO_MORE -> 4u // 5
-                NavStyle.MOVE_HISTORY_TO_MORE -> 2u // 2
-                NavStyle.MOVE_BROWSE_TO_MORE -> 1u // 2
-                // NavStyle.MOVE_MANGA_TO_MORE -> 1u
+                NavStyle.MOVE_UPDATES_TO_MORE -> 5u
+                else -> 1u
             }
             return TabOptions(
                 index = index,
@@ -118,7 +115,7 @@ data object UpdatesTab : Tab {
                 }
                 Unit
             },
-            onCalendarClicked = { navigator.push(UpcomingScreen()) },
+            onCalendarClicked = { navigator.push(mihon.feature.airingschedule.AiringScheduleTab) },
             navigateUp = navigateUp,
         )
 

--- a/app/src/main/java/mihon/feature/airingschedule/AiringScheduleEntry.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/AiringScheduleEntry.kt
@@ -1,0 +1,28 @@
+package mihon.feature.airingschedule
+
+data class AiringScheduleEntry(
+    val scheduleId: Int,
+    val airingAt: Long,
+    val episode: Int,
+    val mediaId: Int,
+    val titleUserPreferred: String,
+    val titleEnglish: String?,
+    val titleRomaji: String?,
+    val titleNative: String?,
+    val coverImageUrl: String,
+    val totalEpisodes: Int?,
+    val averageScore: Int?,
+    val format: String?,
+    val status: String?,
+    val isAdult: Boolean,
+    val genres: List<String>,
+) {
+    fun displayTitle(language: SchedulePreferences.TitleLanguage): String = when (language) {
+        SchedulePreferences.TitleLanguage.ENGLISH -> titleEnglish?.takeIf { it.isNotBlank() } ?: titleRomaji?.takeIf { it.isNotBlank() } ?: titleUserPreferred
+        SchedulePreferences.TitleLanguage.ROMAJI -> titleRomaji?.takeIf { it.isNotBlank() } ?: titleUserPreferred
+        SchedulePreferences.TitleLanguage.NATIVE -> titleNative?.takeIf { it.isNotBlank() } ?: titleUserPreferred
+        SchedulePreferences.TitleLanguage.USER_PREFERRED -> titleUserPreferred
+    }
+
+    fun hasAired(): Boolean = airingAt <= System.currentTimeMillis() / 1000L
+}

--- a/app/src/main/java/mihon/feature/airingschedule/AiringScheduleRepository.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/AiringScheduleRepository.kt
@@ -1,0 +1,239 @@
+package mihon.feature.airingschedule
+
+import eu.kanade.tachiyomi.network.HttpException
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.jsonMime
+import eu.kanade.tachiyomi.network.parseAs
+import kotlinx.coroutines.delay
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import okhttp3.RequestBody.Companion.toRequestBody
+import tachiyomi.core.common.util.lang.withIOContext
+import uy.kohesive.injekt.injectLazy
+import java.io.IOException
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.random.Random
+
+/**
+ * Fetches the weekly airing schedule from AniList's GraphQL API.
+ *
+ * AniList is a public data API (not a browser-rendered site), so any transient 403/429/503
+ * response it returns is virtually never an interactive Cloudflare challenge that a WebView
+ * could solve - it is almost always AniList's own rate limiting kicking in when many page
+ * requests are made back-to-back. To make the weekly refresh reliable long-term, every request
+ * here is retried with exponential backoff + jitter, and pages are spaced out slightly, instead
+ * of surfacing a hard failure to the user for a transient hiccup.
+ */
+class AiringScheduleRepository {
+
+    private val networkHelper: NetworkHelper by injectLazy()
+    private val json: Json by injectLazy()
+
+    private val client get() = networkHelper.client
+
+    suspend fun getWeeklySchedule(
+        weekStart: Long,
+        weekEnd: Long,
+        includeAdult: Boolean = false,
+    ): List<AiringScheduleEntry> {
+        return withIOContext {
+            var page = 1
+            val allEntries = mutableListOf<AiringScheduleEntry>()
+            var hasNextPage = true
+            while (hasNextPage && page <= 10) {
+                val result = fetchPageWithRetry(weekStart, weekEnd, page, includeAdult)
+                allEntries.addAll(result.entries)
+                hasNextPage = result.hasNextPage
+                page++
+                if (hasNextPage) {
+                    // Small courtesy delay between paginated requests so we don't look like a
+                    // burst/bot to AniList's own rate limiter or edge network.
+                    delay(PAGE_DELAY_MS)
+                }
+            }
+            allEntries
+        }
+    }
+
+    private suspend fun fetchPageWithRetry(
+        weekStart: Long,
+        weekEnd: Long,
+        page: Int,
+        includeAdult: Boolean,
+    ): PageResult {
+        var attempt = 0
+        var lastError: Exception? = null
+        while (attempt < MAX_RETRIES) {
+            try {
+                return fetchPage(weekStart, weekEnd, page, includeAdult)
+            } catch (e: HttpException) {
+                lastError = e
+                if (e.code !in RETRYABLE_HTTP_CODES) throw e
+            } catch (e: IOException) {
+                lastError = e
+            }
+            attempt++
+            if (attempt < MAX_RETRIES) {
+                delay(backoffDelayMs(attempt))
+            }
+        }
+        throw lastError ?: IOException("Failed to fetch airing schedule")
+    }
+
+    private fun backoffDelayMs(attempt: Int): Long {
+        val exponential = BASE_DELAY_MS * 2.0.pow(attempt - 1).toLong()
+        val jitter = Random.nextLong(0, 500)
+        return min(exponential + jitter, MAX_DELAY_MS)
+    }
+
+    private suspend fun fetchPage(
+        weekStart: Long,
+        weekEnd: Long,
+        page: Int,
+        includeAdult: Boolean,
+    ): PageResult {
+        val query = """
+        |query AiringSchedule(${'$'}weekStart: Int, ${'$'}weekEnd: Int, ${'$'}page: Int) {
+            |Page(page: ${'$'}page, perPage: 50) {
+                |pageInfo {
+                    |hasNextPage
+                |}
+                |airingSchedules(airingAt_greater: ${'$'}weekStart, airingAt_lesser: ${'$'}weekEnd, sort: TIME) {
+                    |id
+                    |airingAt
+                    |episode
+                    |media {
+                        |id
+                        |title {
+                            |userPreferred
+                            |english
+                            |romaji
+                            |native
+                        |}
+                        |coverImage {
+                            |large
+                        |}
+                        |episodes
+                        |status
+                        |averageScore
+                        |format
+                        |isAdult
+                        |genres
+                    |}
+                |}
+            |}
+        |}
+        """.trimMargin()
+
+        val payload = buildJsonObject {
+            put("query", query)
+            putJsonObject("variables") {
+                put("weekStart", weekStart.toInt())
+                put("weekEnd", weekEnd.toInt())
+                put("page", page)
+            }
+        }
+
+        with(json) {
+            val result = client.newCall(
+                POST(API_URL, body = payload.toString().toRequestBody(jsonMime)),
+            ).awaitSuccess().parseAs<ALScheduleResponse>()
+
+            return PageResult(
+                entries = result.data.page.airingSchedules.mapNotNull { it.toEntry(includeAdult) },
+                hasNextPage = result.data.page.pageInfo.hasNextPage,
+            )
+        }
+    }
+
+    private fun ALAiringSchedule.toEntry(includeAdult: Boolean): AiringScheduleEntry? {
+        val m = media ?: return null
+        if (!includeAdult && m.isAdult == true) return null
+        return AiringScheduleEntry(
+            scheduleId = id,
+            airingAt = airingAt.toLong(),
+            episode = episode,
+            mediaId = m.id,
+            titleUserPreferred = m.title.userPreferred.orEmpty(),
+            titleEnglish = m.title.english,
+            titleRomaji = m.title.romaji,
+            titleNative = m.title.native,
+            coverImageUrl = m.coverImage.large.orEmpty(),
+            totalEpisodes = m.episodes,
+            averageScore = m.averageScore,
+            format = m.format,
+            status = m.status,
+            isAdult = m.isAdult ?: false,
+            genres = m.genres.orEmpty(),
+        )
+    }
+
+    private data class PageResult(val entries: List<AiringScheduleEntry>, val hasNextPage: Boolean)
+
+    companion object {
+        private const val API_URL = "https://graphql.anilist.co/"
+
+        // Transient errors worth retrying: 429 (rate limited), 502/503/504 (upstream hiccups).
+        // 403 is intentionally excluded - AniList returns that for genuinely bad requests, and
+        // retrying it would just waste time.
+        private val RETRYABLE_HTTP_CODES = setOf(429, 502, 503, 504)
+        private const val MAX_RETRIES = 5
+        private const val BASE_DELAY_MS = 1000L
+        private const val MAX_DELAY_MS = 20_000L
+        private const val PAGE_DELAY_MS = 250L
+    }
+}
+
+@Serializable
+private data class ALScheduleResponse(val data: ALScheduleData)
+
+@Serializable
+private data class ALScheduleData(@SerialName("Page") val page: ALSchedulePage)
+
+@Serializable
+private data class ALSchedulePage(
+    val pageInfo: ALPageInfo,
+    val airingSchedules: List<ALAiringSchedule>,
+)
+
+@Serializable
+private data class ALPageInfo(val hasNextPage: Boolean)
+
+@Serializable
+private data class ALAiringSchedule(
+    val id: Int,
+    val airingAt: Int,
+    val episode: Int,
+    val media: ALMedia? = null,
+)
+
+@Serializable
+private data class ALMedia(
+    val id: Int,
+    val title: ALTitle,
+    val coverImage: ALCoverImage,
+    val episodes: Int? = null,
+    val status: String? = null,
+    val averageScore: Int? = null,
+    val format: String? = null,
+    val isAdult: Boolean? = null,
+    val genres: List<String>? = null,
+)
+
+@Serializable
+private data class ALTitle(
+    val userPreferred: String? = null,
+    val english: String? = null,
+    val romaji: String? = null,
+    val native: String? = null,
+)
+
+@Serializable
+private data class ALCoverImage(val large: String? = null)

--- a/app/src/main/java/mihon/feature/airingschedule/AiringScheduleScreenModel.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/AiringScheduleScreenModel.kt
@@ -1,0 +1,284 @@
+package mihon.feature.airingschedule
+
+import android.app.Application
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import eu.kanade.domain.source.service.SourcePreferences
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import mihon.feature.airingschedule.notification.ScheduleNotifications
+import tachiyomi.domain.anime.interactor.GetLibraryAnime
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.TemporalAdjusters
+
+class AiringScheduleScreenModel : StateScreenModel<AiringScheduleScreenModel.State>(State()) {
+
+    private val repository = AiringScheduleRepository()
+    private val schedulePrefs: SchedulePreferences = Injekt.get()
+    private val sourcePreferences: SourcePreferences = Injekt.get()
+    private val uploadDelayTracker: UploadDelayTracker = Injekt.get()
+    private val application: Application = Injekt.get()
+    private val getLibraryAnime: GetLibraryAnime = Injekt.get()
+
+    private var allEntries: List<AiringScheduleEntry> = emptyList()
+    private var hasLoaded = false
+
+    init {
+        loadSchedule()
+        observePreferences()
+        observeLibrary()
+    }
+
+    private fun observeLibrary() {
+        screenModelScope.launch {
+            getLibraryAnime.subscribe().collectLatest { libraryAnime ->
+                val titles = libraryAnime.map { lib ->
+                    lib.anime.title.trim().lowercase()
+                }.toSet()
+                val sourcesByTitle = libraryAnime
+                    .groupBy({ it.anime.title.trim().lowercase() }, { it.anime.source.toString() })
+                    .mapValues { it.value.toSet() }
+                mutableState.update { it.copy(libraryAnimeTitles = titles, librarySourcesByTitle = sourcesByTitle) }
+                applyFilters()
+            }
+        }
+    }
+
+    private fun observePreferences() {
+        screenModelScope.launch {
+            combine(
+                schedulePrefs.showAdultContent().changes(),
+                schedulePrefs.titleLanguage().changes(),
+                schedulePrefs.uploadDelayRefreshInterval().changes(),
+                schedulePrefs.customUploadDelayMinutes().changes(),
+            ) { _ -> Unit }.collectLatest {
+                if (hasLoaded) applyFilters()
+            }
+        }
+    }
+
+    fun loadSchedule() {
+        screenModelScope.launch {
+            mutableState.update { it.copy(isLoading = true, error = null) }
+            val zone = ZoneId.systemDefault()
+            val now = ZonedDateTime.now(zone)
+            val weekStart = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .toLocalDate().atStartOfDay(zone)
+            val weekEnd = weekStart.plusDays(7).minusSeconds(1)
+            val currentWeekStart = weekStart.toEpochSecond()
+
+            try {
+                val autoRefreshEnabled = schedulePrefs.scheduleAutoRefreshEnabled().get()
+                val cache = ScheduleDataRefreshWorker.readCache(application)
+                val entries: List<AiringScheduleEntry> = if (autoRefreshEnabled &&
+                    cache != null &&
+                    cache.weekStartEpoch == currentWeekStart &&
+                    ScheduleDataRefreshWorker.isCacheFresh(cache, schedulePrefs.scheduleAutoRefreshFrequency().get())
+                ) {
+                    cache.entries.map { it.toEntry() }
+                } else {
+                    val includeAdult = schedulePrefs.showAdultContent().get()
+                    try {
+                        val fetched = repository.getWeeklySchedule(
+                            weekStart.toEpochSecond(),
+                            weekEnd.toEpochSecond(),
+                            includeAdult = includeAdult,
+                        )
+                        ScheduleDataRefreshWorker.writeCache(application, currentWeekStart, fetched)
+                        fetched
+                    } catch (fetchError: Exception) {
+                        val fallback = cache?.takeIf { it.weekStartEpoch == currentWeekStart }
+                        if (fallback != null) {
+                            fallback.entries.map { it.toEntry() }
+                        } else {
+                            throw fetchError
+                        }
+                    }
+                }
+
+                allEntries = entries
+                hasLoaded = true
+
+                val delays = if (schedulePrefs.uploadDelayEnabled().get()) {
+                    uploadDelayTracker.getDelays()
+                } else {
+                    emptyMap()
+                }
+
+                rescheduleSeriesAlarms()
+
+                applyFilters(
+                    entries = allEntries,
+                    delays = delays,
+                    weekStart = weekStart.toLocalDate(),
+                    weekEnd = weekEnd.toLocalDate(),
+                )
+            } catch (e: Exception) {
+                mutableState.update { it.copy(isLoading = false, error = e.message) }
+            }
+        }
+    }
+
+    private fun computeManualDelayMinutes(): Long? {
+        if (!schedulePrefs.uploadDelayEnabled().get()) return null
+        if (schedulePrefs.uploadDelayRefreshInterval().get() != SchedulePreferences.UploadDelayInterval.CUSTOM) {
+            return null
+        }
+        return SchedulePreferences.parseCustomDelayMinutes(schedulePrefs.customUploadDelayMinutes().get())
+    }
+
+    private fun matchedSourcesFor(
+        entry: AiringScheduleEntry,
+        configuredSources: Set<String>,
+        librarySourcesByTitle: Map<String, Set<String>>,
+    ): Set<String> {
+        val titleCandidates = listOfNotNull(
+            entry.titleUserPreferred,
+            entry.titleEnglish,
+            entry.titleRomaji,
+            entry.titleNative,
+        ).map { it.trim().lowercase() }
+        val candidateSources = titleCandidates.flatMap { librarySourcesByTitle[it].orEmpty() }.toSet()
+        return candidateSources.intersect(configuredSources)
+    }
+
+    private fun priorityDelayFor(
+        matchedSources: Set<String>,
+        manualDelayMinutes: Long?,
+        delays: Map<String, Long>,
+        pinnedSources: Set<String>,
+    ): Long? {
+        manualDelayMinutes?.let { return it }
+        if (delays.isEmpty() || matchedSources.isEmpty()) return null
+        for (sourceId in pinnedSources) {
+            if (sourceId in matchedSources) delays[sourceId]?.let { return it }
+        }
+        return null
+    }
+
+    private fun groupByDelayAdjustedDay(
+        entries: List<AiringScheduleEntry>,
+        configuredSources: Set<String>,
+        librarySourcesByTitle: Map<String, Set<String>>,
+        manualDelayMinutes: Long?,
+        delays: Map<String, Long>,
+        pinnedSources: Set<String>,
+        zone: ZoneId,
+    ): Map<DayOfWeek, List<AiringScheduleEntry>> = entries.groupBy { entry ->
+        val matchedSources = if (configuredSources.isNotEmpty()) {
+            matchedSourcesFor(entry, configuredSources, librarySourcesByTitle)
+        } else {
+            emptySet()
+        }
+        val priorityDelay = priorityDelayFor(matchedSources, manualDelayMinutes, delays, pinnedSources)
+        val airTime = if (priorityDelay != null) entry.airingAt + (priorityDelay * 60) else entry.airingAt
+        ZonedDateTime.ofInstant(Instant.ofEpochSecond(airTime), zone).dayOfWeek
+    }
+
+    private fun applyFilters(
+        entries: List<AiringScheduleEntry> = allEntries,
+        delays: Map<String, Long> = if (schedulePrefs.uploadDelayEnabled().get()) uploadDelayTracker.getDelays() else emptyMap(),
+        weekStart: LocalDate? = mutableState.value.weekStartDate,
+        weekEnd: LocalDate? = mutableState.value.weekEndDate,
+    ) {
+        val showAdult = schedulePrefs.showAdultContent().get()
+        val titleLang = schedulePrefs.titleLanguage().get()
+        val pinnedSources = sourcePreferences.pinnedSources().get()
+        val librarySourcesByTitle = mutableState.value.librarySourcesByTitle
+        val manualDelayMinutes = computeManualDelayMinutes()
+
+        val filtered = entries.filter { !it.isAdult || showAdult }
+        val grouped = groupByDelayAdjustedDay(
+            entries = filtered,
+            configuredSources = pinnedSources,
+            librarySourcesByTitle = librarySourcesByTitle,
+            manualDelayMinutes = manualDelayMinutes,
+            delays = delays,
+            pinnedSources = pinnedSources,
+            zone = ZoneId.systemDefault(),
+        )
+
+        mutableState.update {
+            it.copy(
+                isLoading = false,
+                scheduleByDay = grouped,
+                weekStartDate = weekStart,
+                weekEndDate = weekEnd,
+                titleLanguage = titleLang,
+                sourceDelays = delays,
+                manualDelayMinutes = manualDelayMinutes,
+                pinnedSourceIds = pinnedSources,
+                notifyOnceMediaIds = schedulePrefs.notifyOnceMediaIds().get(),
+                notifySeriesMediaIds = schedulePrefs.notifySeriesMediaIds().get(),
+            )
+        }
+    }
+
+    fun toggleNotifyOnce(entry: AiringScheduleEntry) {
+        val key = entry.mediaId.toString()
+        val current = schedulePrefs.notifyOnceMediaIds().get()
+        val seriesCurrent = schedulePrefs.notifySeriesMediaIds().get()
+        if (key in current) {
+            schedulePrefs.notifyOnceMediaIds().set(current - key)
+            ScheduleNotifications.cancel(application, entry)
+        } else {
+            if (ScheduleNotifications.ensureScheduled(application, entry)) {
+                schedulePrefs.notifyOnceMediaIds().set(current + key)
+                schedulePrefs.notifySeriesMediaIds().set(seriesCurrent - key)
+            }
+        }
+        applyFilters()
+    }
+
+    fun toggleNotifySeries(entry: AiringScheduleEntry) {
+        val key = entry.mediaId.toString()
+        val seriesCurrent = schedulePrefs.notifySeriesMediaIds().get()
+        val onceCurrent = schedulePrefs.notifyOnceMediaIds().get()
+        if (key in seriesCurrent) {
+            schedulePrefs.notifySeriesMediaIds().set(seriesCurrent - key)
+            ScheduleNotifications.cancelAllForMedia(application, entry.mediaId, allEntries)
+        } else {
+            schedulePrefs.notifySeriesMediaIds().set(seriesCurrent + key)
+            schedulePrefs.notifyOnceMediaIds().set(onceCurrent - key)
+            rescheduleSeriesAlarms()
+        }
+        applyFilters()
+    }
+
+    private fun rescheduleSeriesAlarms() {
+        val seriesIds = schedulePrefs.notifySeriesMediaIds().get()
+        if (seriesIds.isEmpty()) return
+        allEntries
+            .filter { it.mediaId.toString() in seriesIds && !it.hasAired() }
+            .forEach { ScheduleNotifications.ensureScheduled(application, it) }
+    }
+
+    fun selectDay(day: DayOfWeek) {
+        mutableState.update { it.copy(selectedDay = day) }
+    }
+
+    data class State(
+        val isLoading: Boolean = true,
+        val scheduleByDay: Map<DayOfWeek, List<AiringScheduleEntry>> = emptyMap(),
+        val selectedDay: DayOfWeek = ZonedDateTime.now().dayOfWeek,
+        val weekStartDate: LocalDate? = null,
+        val weekEndDate: LocalDate? = null,
+        val error: String? = null,
+        val titleLanguage: SchedulePreferences.TitleLanguage = SchedulePreferences.TitleLanguage.USER_PREFERRED,
+        val sourceDelays: Map<String, Long> = emptyMap(),
+        val manualDelayMinutes: Long? = null,
+        val pinnedSourceIds: Set<String> = emptySet(),
+        val notifyOnceMediaIds: Set<String> = emptySet(),
+        val notifySeriesMediaIds: Set<String> = emptySet(),
+        val libraryAnimeTitles: Set<String> = emptySet(),
+        val librarySourcesByTitle: Map<String, Set<String>> = emptyMap(),
+    )
+}

--- a/app/src/main/java/mihon/feature/airingschedule/AiringScheduleTab.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/AiringScheduleTab.kt
@@ -1,0 +1,479 @@
+package mihon.feature.airingschedule
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.LibraryBooks
+import androidx.compose.material.icons.outlined.DateRange
+import androidx.compose.material.icons.outlined.NewReleases
+import androidx.compose.material.icons.outlined.Public
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import cafe.adriel.voyager.navigator.tab.TabOptions
+import eu.kanade.presentation.more.settings.screen.SettingsScheduleScreen
+import eu.kanade.presentation.util.Tab
+import eu.kanade.tachiyomi.ui.anime.AnimeScreen
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
+import kotlinx.coroutines.launch
+import mihon.feature.airingschedule.components.BellNotifyState
+import mihon.feature.airingschedule.components.ScheduleAnimeCard
+import mihon.feature.upcoming.UpcomingScreenContent
+import mihon.feature.upcoming.UpcomingScreenModel
+import tachiyomi.domain.library.service.LibraryPreferences.Companion.ANIME_OUTSIDE_RELEASE_PERIOD
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.EmptyScreen
+import tachiyomi.presentation.core.screens.LoadingScreen
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
+
+private val orderedDays = listOf(
+    DayOfWeek.MONDAY,
+    DayOfWeek.TUESDAY,
+    DayOfWeek.WEDNESDAY,
+    DayOfWeek.THURSDAY,
+    DayOfWeek.FRIDAY,
+    DayOfWeek.SATURDAY,
+    DayOfWeek.SUNDAY,
+)
+
+data object AiringScheduleTab : Tab {
+
+    override val options: TabOptions
+        @Composable
+        get() {
+            // Index must match the position produced by NavStyle.tabs after the moreTab is
+            // removed.  Base order: Library(0) Updates(1) History(2) Browse(3) Schedule(4) More(5).
+            val index: UShort = when (currentNavigationStyle()) {
+                eu.kanade.domain.ui.model.NavStyle.MOVE_SCHEDULE_TO_MORE -> 5u
+                eu.kanade.domain.ui.model.NavStyle.MOVE_UPDATES_TO_MORE -> 3u
+                eu.kanade.domain.ui.model.NavStyle.MOVE_HISTORY_TO_MORE -> 3u
+                eu.kanade.domain.ui.model.NavStyle.MOVE_BROWSE_TO_MORE -> 3u
+            }
+            return TabOptions(
+                index = index,
+                title = "Schedule",
+                icon = rememberVectorPainter(Icons.Outlined.DateRange),
+            )
+        }
+
+    override suspend fun onReselect(navigator: Navigator) {}
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val scope = rememberCoroutineScope()
+        val schedulePrefs = remember { Injekt.get<SchedulePreferences>() }
+        val dataSource by schedulePrefs.scheduleDataSource().changes().collectAsState(initial = schedulePrefs.scheduleDataSource().get())
+
+        val isGlobal = dataSource == SchedulePreferences.ScheduleDataSource.ANILIST
+
+        val airingScreenModel = rememberScreenModel { AiringScheduleScreenModel() }
+        val airingState by airingScreenModel.state.collectAsState()
+
+        val upcomingScreenModel = rememberScreenModel { UpcomingScreenModel() }
+        val upcomingState by upcomingScreenModel.state.collectAsState()
+
+        Scaffold(
+            contentWindowInsets = WindowInsets(0),
+            topBar = {
+                TopAppBar(
+                    navigationIcon = {
+                        if (navigator.canPop) {
+                            IconButton(onClick = { navigator.pop() }) {
+                                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
+                            }
+                        }
+                    },
+                    title = {
+                        if (isGlobal) {
+                            Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                                Text(
+                                    text = stringResource(MR.strings.label_airing_schedule),
+                                    style = MaterialTheme.typography.titleLarge,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                                val weekRange = buildWeekRangeLabel(airingState.weekStartDate, airingState.weekEndDate)
+                                if (weekRange.isNotEmpty()) {
+                                    Text(
+                                        text = weekRange,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        } else {
+                            Text(
+                                text = if (upcomingState.isShowingUpdatingMangas) {
+                                    stringResource(tachiyomi.i18n.kmk.KMR.strings.label_to_be_updated)
+                                } else {
+                                    stringResource(MR.strings.label_upcoming)
+                                },
+                            )
+                        }
+                    },
+                    actions = {
+                        if (isGlobal) {
+                            IconButton(onClick = { airingScreenModel.loadSchedule() }) {
+                                Icon(Icons.Outlined.Refresh, contentDescription = stringResource(MR.strings.cd_refresh_schedule))
+                            }
+                        } else {
+                            if (ANIME_OUTSIDE_RELEASE_PERIOD in upcomingScreenModel.restriction) {
+                                IconButton(
+                                    onClick = {
+                                        if (upcomingState.isShowingUpdatingMangas) {
+                                            upcomingScreenModel.hideUpdatingMangas()
+                                        } else {
+                                            upcomingScreenModel.showUpdatingMangas()
+                                        }
+                                    },
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Outlined.NewReleases,
+                                        contentDescription = stringResource(MR.strings.pref_library_update_smart_update),
+                                        tint = if (upcomingState.isShowingUpdatingMangas) MaterialTheme.colorScheme.primary else androidx.compose.material3.LocalContentColor.current,
+                                    )
+                                }
+                            }
+                        }
+
+                        var showMenu by remember { mutableStateOf(false) }
+                        IconButton(onClick = { showMenu = true }) {
+                            Icon(
+                                if (isGlobal) Icons.Outlined.Public else Icons.AutoMirrored.Outlined.LibraryBooks,
+                                contentDescription = null,
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = showMenu,
+                            onDismissRequest = { showMenu = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("AniList (Global)") },
+                                onClick = {
+                                    schedulePrefs.scheduleDataSource().set(SchedulePreferences.ScheduleDataSource.ANILIST)
+                                    showMenu = false
+                                },
+                                leadingIcon = { Icon(Icons.Outlined.Public, contentDescription = null) },
+                                enabled = !isGlobal,
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Smart Updates (Library)") },
+                                onClick = {
+                                    schedulePrefs.scheduleDataSource().set(SchedulePreferences.ScheduleDataSource.SMART_UPDATES)
+                                    showMenu = false
+                                },
+                                leadingIcon = { Icon(Icons.AutoMirrored.Outlined.LibraryBooks, contentDescription = null) },
+                                enabled = isGlobal,
+                            )
+                        }
+
+                        IconButton(onClick = { navigator.push(SettingsScheduleScreen) }) {
+                            Icon(Icons.Outlined.Settings, contentDescription = stringResource(MR.strings.cd_schedule_settings))
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                    ),
+                )
+            },
+        ) { paddingValues ->
+            if (isGlobal) {
+                AiringScheduleContent(
+                    state = airingState,
+                    paddingValues = paddingValues,
+                    screenModel = airingScreenModel,
+                    navigator = navigator,
+                    scope = scope,
+                )
+            } else {
+                UpcomingScreenContent(
+                    state = upcomingState,
+                    setSelectedYearMonth = upcomingScreenModel::setSelectedYearMonth,
+                    onClickUpcoming = { navigator.push(AnimeScreen(it.id)) },
+                    showUpdatingMangas = upcomingScreenModel::showUpdatingMangas,
+                    hideUpdatingMangas = upcomingScreenModel::hideUpdatingMangas,
+                    isPredictReleaseDate = ANIME_OUTSIDE_RELEASE_PERIOD in upcomingScreenModel.restriction,
+                    modifier = Modifier.padding(paddingValues),
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AiringScheduleContent(
+    state: AiringScheduleScreenModel.State,
+    paddingValues: PaddingValues,
+    screenModel: AiringScheduleScreenModel,
+    navigator: Navigator,
+    scope: kotlinx.coroutines.CoroutineScope,
+) {
+    val todayIndex = orderedDays.indexOf(state.selectedDay).coerceAtLeast(0)
+    val pagerState = rememberPagerState(initialPage = todayIndex) { orderedDays.size }
+
+    LaunchedEffect(pagerState.currentPage) {
+        screenModel.selectDay(orderedDays[pagerState.currentPage])
+    }
+
+    when {
+        state.isLoading -> LoadingScreen(modifier = Modifier.padding(paddingValues))
+        state.error != null -> ScheduleErrorContent(
+            error = state.error!!,
+            onRetry = { screenModel.loadSchedule() },
+            modifier = Modifier.padding(paddingValues),
+        )
+        else -> Column(modifier = Modifier.padding(paddingValues)) {
+            ScheduleDayTabRow(
+                pagerState = pagerState,
+                weekStartDate = state.weekStartDate,
+                scheduleByDay = state.scheduleByDay,
+                onTabClick = { index -> scope.launch { pagerState.animateScrollToPage(index) } },
+            )
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize(),
+            ) { pageIndex ->
+                val day = orderedDays[pageIndex]
+                val entries = state.scheduleByDay[day] ?: emptyList()
+                ScheduleDayContent(
+                    entries = entries,
+                    titleLanguage = state.titleLanguage,
+                    sourceDelays = state.sourceDelays,
+                    manualDelayMinutes = state.manualDelayMinutes,
+                    pinnedSourceIds = state.pinnedSourceIds,
+                    libraryAnimeTitles = state.libraryAnimeTitles,
+                    onSearchClick = { title ->
+                        navigator.push(
+                            GlobalSearchScreen(
+                                searchQuery = title,
+                                initialSourceFilter = SourceFilter.PinnedOnly,
+                            ),
+                        )
+                    },
+                    onAddToLibraryClick = { title ->
+                        navigator.push(
+                            GlobalSearchScreen(
+                                searchQuery = title,
+                                initialSourceFilter = SourceFilter.PinnedOnly,
+                            ),
+                        )
+                    },
+                    notifyOnceMediaIds = state.notifyOnceMediaIds,
+                    notifySeriesMediaIds = state.notifySeriesMediaIds,
+                    onToggleNotifyOnce = { entry -> screenModel.toggleNotifyOnce(entry) },
+                    onToggleNotifySeries = { entry -> screenModel.toggleNotifySeries(entry) },
+                )
+            }
+        }
+    }
+}
+
+private fun buildWeekRangeLabel(start: LocalDate?, end: LocalDate?): String {
+    if (start == null || end == null) return ""
+    val fmt = DateTimeFormatter.ofPattern("MMM d")
+    return "${start.format(fmt)} – ${end.format(fmt)}"
+}
+
+@Composable
+private fun ScheduleDayTabRow(
+    pagerState: PagerState,
+    weekStartDate: LocalDate?,
+    scheduleByDay: Map<DayOfWeek, List<AiringScheduleEntry>>,
+    onTabClick: (Int) -> Unit,
+) {
+    val today = LocalDate.now().dayOfWeek
+    ScrollableTabRow(
+        selectedTabIndex = pagerState.currentPage,
+        containerColor = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.primary,
+        edgePadding = 8.dp,
+    ) {
+        orderedDays.forEachIndexed { index, day ->
+            val isToday = day == today
+            val dayDate = weekStartDate?.plusDays(orderedDays.indexOf(day).toLong())
+            val count = scheduleByDay[day]?.size ?: 0
+            val dayShort = day.getDisplayName(TextStyle.SHORT, Locale.getDefault())
+            Tab(
+                selected = pagerState.currentPage == index,
+                onClick = { onTabClick(index) },
+                text = {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        Text(
+                            text = dayShort,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = if (isToday) FontWeight.ExtraBold else FontWeight.Normal,
+                            color = if (isToday && pagerState.currentPage != index) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
+                        )
+                        dayDate?.let { date ->
+                            Text(
+                                text = date.dayOfMonth.toString(),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        if (count > 0) {
+                            Text(
+                                text = "$count",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScheduleDayContent(
+    entries: List<AiringScheduleEntry>,
+    titleLanguage: SchedulePreferences.TitleLanguage,
+    sourceDelays: Map<String, Long>,
+    manualDelayMinutes: Long?,
+    pinnedSourceIds: Set<String>,
+    libraryAnimeTitles: Set<String>,
+    onSearchClick: (String) -> Unit,
+    onAddToLibraryClick: (String) -> Unit,
+    notifyOnceMediaIds: Set<String>,
+    notifySeriesMediaIds: Set<String>,
+    onToggleNotifyOnce: (AiringScheduleEntry) -> Unit,
+    onToggleNotifySeries: (AiringScheduleEntry) -> Unit,
+) {
+    if (entries.isEmpty()) {
+        EmptyScreen(stringRes = tachiyomi.i18n.MR.strings.information_no_airing_today)
+        return
+    }
+    val listState = rememberLazyListState()
+    LazyColumn(
+        state = listState,
+        contentPadding = PaddingValues(vertical = 8.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        items(items = entries, key = { it.scheduleId }) { entry ->
+            val mediaKey = entry.mediaId.toString()
+            val notifyState = when {
+                mediaKey in notifySeriesMediaIds -> BellNotifyState.SERIES
+                mediaKey in notifyOnceMediaIds -> BellNotifyState.ONCE
+                else -> BellNotifyState.NONE
+            }
+            val isInLibrary = entry.titleUserPreferred.trim().lowercase() in libraryAnimeTitles ||
+                entry.titleEnglish?.trim()?.lowercase() in libraryAnimeTitles ||
+                entry.titleRomaji?.trim()?.lowercase() in libraryAnimeTitles ||
+                entry.titleNative?.trim()?.lowercase() in libraryAnimeTitles
+            ScheduleAnimeCard(
+                entry = entry,
+                titleLanguage = titleLanguage,
+                sourceDelays = sourceDelays,
+                manualDelayMinutes = manualDelayMinutes,
+                pinnedSourceIds = pinnedSourceIds,
+                isInLibrary = isInLibrary,
+                notifyState = notifyState,
+                onSearchClick = onSearchClick,
+                onAddToLibraryClick = onAddToLibraryClick,
+                onToggleNotifyOnce = { onToggleNotifyOnce(entry) },
+                onToggleNotifySeries = { onToggleNotifySeries(entry) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScheduleErrorContent(
+    error: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth().padding(32.dp),
+        ) {
+            Text(
+                text = stringResource(MR.strings.schedule_error_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            FilledTonalButton(onClick = onRetry) {
+                Icon(
+                    imageVector = Icons.Outlined.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 6.dp),
+                )
+                Text(stringResource(MR.strings.action_retry))
+            }
+        }
+    }
+}

--- a/app/src/main/java/mihon/feature/airingschedule/ScheduleDataRefreshWorker.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/ScheduleDataRefreshWorker.kt
@@ -1,0 +1,220 @@
+package mihon.feature.airingschedule
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.time.DayOfWeek
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.TemporalAdjusters
+import java.util.concurrent.TimeUnit
+
+/**
+ * Periodic WorkManager job that automatically refreshes the weekly airing schedule
+ * from AniList and caches it locally. Frequency is configurable by the user
+ * (1–7 days). Disabled by default.
+ */
+class ScheduleDataRefreshWorker(
+    private val context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        try {
+            val schedulePrefs = Injekt.get<SchedulePreferences>()
+
+            if (!schedulePrefs.scheduleAutoRefreshEnabled().get()) {
+                return@withContext Result.success()
+            }
+
+            val repository = AiringScheduleRepository()
+            val includeAdult = schedulePrefs.showAdultContent().get()
+
+            val zone = ZoneId.systemDefault()
+            val now = ZonedDateTime.now(zone)
+            val weekStart = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .toLocalDate().atStartOfDay(zone)
+            val weekEnd = weekStart.plusDays(7).minusSeconds(1)
+
+            val entries = repository.getWeeklySchedule(
+                weekStart.toEpochSecond(),
+                weekEnd.toEpochSecond(),
+                includeAdult = includeAdult,
+            )
+
+            writeCache(context, weekStart.toEpochSecond(), entries)
+
+            // Re-arm alarms for any anime the user subscribed to "notify every episode" for.
+            // Series alarms are only ever scheduled from whichever week is currently loaded in
+            // the UI, so without this, a series subscription silently stops alerting once the
+            // originally-loaded week's episodes are exhausted. This periodic refresh (which runs
+            // independently of the Schedule tab being open) re-schedules alarms for each newly
+            // fetched week's unaired episodes belonging to a subscribed series.
+            val seriesIds = schedulePrefs.notifySeriesMediaIds().get()
+            if (seriesIds.isNotEmpty()) {
+                entries
+                    .filter { it.mediaId.toString() in seriesIds && !it.hasAired() }
+                    .forEach { mihon.feature.airingschedule.notification.ScheduleNotifications.ensureScheduled(context, it) }
+            }
+
+            schedulePrefs.scheduleLastAutoRefresh().set(System.currentTimeMillis())
+            Result.success()
+        } catch (_: Exception) {
+            // WorkManager will retry this with the exponential backoff policy configured in
+            // `schedule()` below, so a transient failure here (rate limiting, no network, etc.)
+            // self-heals without any user action.
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val WORK_NAME = "ScheduleDataRefreshWorker"
+        private val cacheJson = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+        private fun Context.cacheFile() = java.io.File(filesDir, "schedule_cache.json")
+
+        fun schedule(context: Context, frequency: SchedulePreferences.AutoRefreshFrequency) {
+            val days = frequency.toDays()
+            val request = PeriodicWorkRequestBuilder<ScheduleDataRefreshWorker>(days, TimeUnit.DAYS)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build(),
+                )
+                // If a refresh attempt fails (e.g. transient network/rate-limit issue), WorkManager
+                // retries with growing delays instead of hammering the API or giving up until the
+                // next full period, so the "one week ends, next week fails to load" scenario
+                // self-heals well before the week is over.
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(WORK_NAME, ExistingPeriodicWorkPolicy.UPDATE, request)
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+        }
+
+        suspend fun readCache(context: Context): ScheduleCacheData? = withContext(Dispatchers.IO) {
+            try {
+                val file = context.cacheFile()
+                if (!file.exists()) return@withContext null
+                cacheJson.decodeFromString(ScheduleCacheData.serializer(), file.readText())
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        /**
+         * Persists a successfully fetched schedule to disk so it survives app process death and
+         * can be used as a fallback if a later refresh attempt fails. Safe to call regardless of
+         * whether auto-refresh is enabled.
+         */
+        suspend fun writeCache(context: Context, weekStartEpoch: Long, entries: List<AiringScheduleEntry>) =
+            withContext(Dispatchers.IO) {
+                try {
+                    val cacheData = ScheduleCacheData(
+                        fetchedAt = System.currentTimeMillis(),
+                        weekStartEpoch = weekStartEpoch,
+                        entries = entries.map { it.toCached() },
+                    )
+                    val file = context.cacheFile()
+                    file.parentFile?.mkdirs()
+                    file.writeText(cacheJson.encodeToString(ScheduleCacheData.serializer(), cacheData))
+                } catch (_: Exception) {
+                    // Best-effort cache write; failing to persist shouldn't break the current load.
+                }
+            }
+
+        fun isCacheFresh(cacheData: ScheduleCacheData, frequency: SchedulePreferences.AutoRefreshFrequency): Boolean {
+            val maxAge = frequency.toDays() * 24L * 60L * 60L * 1000L
+            val age = System.currentTimeMillis() - cacheData.fetchedAt
+            return age < maxAge
+        }
+
+        private fun SchedulePreferences.AutoRefreshFrequency.toDays(): Long = when (this) {
+            SchedulePreferences.AutoRefreshFrequency.EVERY_1_DAY -> 1L
+            SchedulePreferences.AutoRefreshFrequency.EVERY_2_DAYS -> 2L
+            SchedulePreferences.AutoRefreshFrequency.EVERY_3_DAYS -> 3L
+            SchedulePreferences.AutoRefreshFrequency.EVERY_4_DAYS -> 4L
+            SchedulePreferences.AutoRefreshFrequency.EVERY_5_DAYS -> 5L
+            SchedulePreferences.AutoRefreshFrequency.EVERY_6_DAYS -> 6L
+            SchedulePreferences.AutoRefreshFrequency.EVERY_7_DAYS -> 7L
+        }
+    }
+}
+
+private fun AiringScheduleEntry.toCached() = CachedAiringEntry(
+    scheduleId = scheduleId,
+    airingAt = airingAt,
+    episode = episode,
+    mediaId = mediaId,
+    titleUserPreferred = titleUserPreferred,
+    titleEnglish = titleEnglish,
+    titleRomaji = titleRomaji,
+    titleNative = titleNative,
+    coverImageUrl = coverImageUrl,
+    totalEpisodes = totalEpisodes,
+    averageScore = averageScore,
+    format = format,
+    status = status,
+    isAdult = isAdult,
+    genres = genres,
+)
+
+fun CachedAiringEntry.toEntry() = AiringScheduleEntry(
+    scheduleId = scheduleId,
+    airingAt = airingAt,
+    episode = episode,
+    mediaId = mediaId,
+    titleUserPreferred = titleUserPreferred,
+    titleEnglish = titleEnglish,
+    titleRomaji = titleRomaji,
+    titleNative = titleNative,
+    coverImageUrl = coverImageUrl,
+    totalEpisodes = totalEpisodes,
+    averageScore = averageScore,
+    format = format,
+    status = status,
+    isAdult = isAdult,
+    genres = genres,
+)
+
+@Serializable
+data class ScheduleCacheData(
+    val fetchedAt: Long,
+    val weekStartEpoch: Long,
+    val entries: List<CachedAiringEntry>,
+)
+
+@Serializable
+data class CachedAiringEntry(
+    val scheduleId: Int,
+    val airingAt: Long,
+    val episode: Int,
+    val mediaId: Int,
+    val titleUserPreferred: String,
+    val titleEnglish: String? = null,
+    val titleRomaji: String? = null,
+    val titleNative: String? = null,
+    val coverImageUrl: String,
+    val totalEpisodes: Int? = null,
+    val averageScore: Int? = null,
+    val format: String? = null,
+    val status: String? = null,
+    val isAdult: Boolean = false,
+    val genres: List<String> = emptyList(),
+)

--- a/app/src/main/java/mihon/feature/airingschedule/SchedulePreferences.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/SchedulePreferences.kt
@@ -1,0 +1,99 @@
+package mihon.feature.airingschedule
+
+import tachiyomi.core.common.preference.PreferenceStore
+import tachiyomi.core.common.preference.getEnum
+
+class SchedulePreferences(
+    private val preferenceStore: PreferenceStore,
+) {
+    enum class TitleLanguage { USER_PREFERRED, ENGLISH, ROMAJI, NATIVE }
+    enum class UploadDelayInterval { THIRTY_MIN, ONE_HOUR, TWO_HOURS, SIX_HOURS, TWELVE_HOURS, CUSTOM, NEVER }
+    enum class AutoRefreshFrequency { EVERY_1_DAY, EVERY_2_DAYS, EVERY_3_DAYS, EVERY_4_DAYS, EVERY_5_DAYS, EVERY_6_DAYS, EVERY_7_DAYS }
+    enum class ScheduleDataSource { ANILIST, SMART_UPDATES }
+
+    fun scheduleDataSource() = preferenceStore.getEnum(
+        "schedule_data_source",
+        ScheduleDataSource.ANILIST,
+    )
+
+    fun titleLanguage() = preferenceStore.getEnum(
+        "schedule_title_language",
+        TitleLanguage.USER_PREFERRED,
+    )
+
+    fun showAdultContent() = preferenceStore.getBoolean(
+        "schedule_show_adult_content",
+        false,
+    )
+
+    fun uploadDelayEnabled() = preferenceStore.getBoolean(
+        "schedule_upload_delay_enabled",
+        false,
+    )
+
+    fun uploadDelayRefreshInterval() = preferenceStore.getEnum(
+        "schedule_upload_delay_interval",
+        UploadDelayInterval.ONE_HOUR,
+    )
+
+    /**
+     * User-entered manual upload delay, in minutes (stored as a string so it can back an
+     * [eu.kanade.presentation.more.settings.Preference.PreferenceItem.EditTextPreference]),
+     * used when [uploadDelayRefreshInterval] is set to [UploadDelayInterval.CUSTOM]. Added to
+     * the official AniList air time to shift the displayed expected upload time and episode
+     * countdown, in place of the auto-learned per-source delay.
+     */
+    fun customUploadDelayMinutes() = preferenceStore.getString(
+        "schedule_custom_upload_delay_minutes",
+        "60",
+    )
+
+    fun sourceUploadDelays() = preferenceStore.getString(
+        "schedule_source_upload_delays",
+        "{}",
+    )
+
+    fun lastDelayCheckTime() = preferenceStore.getLong(
+        "schedule_last_delay_check_time",
+        0L,
+    )
+
+    fun scheduleAutoRefreshEnabled() = preferenceStore.getBoolean(
+        "schedule_auto_refresh_enabled",
+        false,
+    )
+
+    fun scheduleAutoRefreshFrequency() = preferenceStore.getEnum(
+        "schedule_auto_refresh_frequency",
+        AutoRefreshFrequency.EVERY_7_DAYS,
+    )
+
+    fun scheduleLastAutoRefresh() = preferenceStore.getLong(
+        "schedule_last_auto_refresh",
+        0L,
+    )
+
+    /** Media ids for which the user wants a single alert for the next upcoming episode. */
+    fun notifyOnceMediaIds() = preferenceStore.getStringSet(
+        "schedule_notify_once_media_ids",
+        emptySet(),
+    )
+
+    /** Media ids for which the user wants alerts for every episode until the series finishes. */
+    fun notifySeriesMediaIds() = preferenceStore.getStringSet(
+        "schedule_notify_series_media_ids",
+        emptySet(),
+    )
+
+    /** Composite "mediaId:episode" keys for which an alarm has already been scheduled. */
+    fun scheduledAlarmKeys() = preferenceStore.getStringSet(
+        "schedule_scheduled_alarm_keys",
+        emptySet(),
+    )
+
+    companion object {
+        /** Parses [customUploadDelayMinutes]'s raw string, clamped to a sane range. Falls back to 0 (no shift) if invalid. */
+        fun parseCustomDelayMinutes(raw: String): Long =
+            raw.trim().toLongOrNull()?.coerceIn(-24 * 60L, 24 * 60L) ?: 0L
+    }
+}

--- a/app/src/main/java/mihon/feature/airingschedule/ScheduleRefreshWorker.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/ScheduleRefreshWorker.kt
@@ -1,0 +1,211 @@
+package mihon.feature.airingschedule
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import eu.kanade.domain.anime.model.toSAnime
+import eu.kanade.domain.source.service.SourcePreferences
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.domain.anime.interactor.GetLibraryAnime
+import tachiyomi.domain.anime.model.Anime
+import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.time.DayOfWeek
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.TemporalAdjusters
+import java.util.concurrent.TimeUnit
+import kotlin.math.abs
+
+/**
+ * Periodic WorkManager job that:
+ *  1. Refreshes the airing schedule cache weekly.
+ *  2. For episodes that have aired and match an anime already in the user's library from a
+ *     favorite/pinned source, fetches that specific source's real episode list and compares its
+ *     actual upload timestamp against AniList's official air time to learn a genuine per-source
+ *     upload delay. Scoped to library anime only (not every source's full catalogue) so this
+ *     stays fast — it never crawls every anime on every source.
+ */
+class ScheduleRefreshWorker(
+    private val context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result = withIOContext {
+        try {
+            val schedulePrefs = Injekt.get<SchedulePreferences>()
+            if (!schedulePrefs.uploadDelayEnabled().get()) return@withIOContext Result.success()
+
+            val nowEpoch = System.currentTimeMillis() / 1000L
+            val trackedSourceIds = Injekt.get<SourcePreferences>().pinnedSources().get()
+            if (trackedSourceIds.isEmpty()) return@withIOContext Result.success()
+
+            val airedEntries = fetchAiredEntries(schedulePrefs, nowEpoch)
+            if (airedEntries.isEmpty()) {
+                schedulePrefs.lastDelayCheckTime().set(nowEpoch)
+                return@withIOContext Result.success()
+            }
+
+            // Bound the work to anime already in the user's library that live on a
+            // favorite/pinned source — this is the only set where we can resolve a concrete
+            // (anime, source) pair to actually query, so we never scan every source's full
+            // catalogue for every scheduled anime.
+            val libraryAnime = Injekt.get<GetLibraryAnime>().await()
+                .map { it.anime }
+                .filter { it.source.toString() in trackedSourceIds }
+            if (libraryAnime.isEmpty()) {
+                schedulePrefs.lastDelayCheckTime().set(nowEpoch)
+                return@withIOContext Result.success()
+            }
+
+            val observations = collectDelayObservations(airedEntries, libraryAnime)
+            Injekt.get<UploadDelayTracker>().recordObservations(observations)
+
+            schedulePrefs.lastDelayCheckTime().set(nowEpoch)
+            Result.success()
+        } catch (_: Exception) {
+            Result.retry()
+        }
+    }
+
+    /** Fetches this week's schedule and returns only the entries that aired since the last check. */
+    private suspend fun fetchAiredEntries(
+        schedulePrefs: SchedulePreferences,
+        nowEpoch: Long,
+    ): List<AiringScheduleEntry> {
+        val zone = ZoneId.systemDefault()
+        val now = ZonedDateTime.now(zone)
+        val weekStart = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            .toLocalDate().atStartOfDay(zone)
+        val weekEnd = weekStart.plusDays(7).minusSeconds(1)
+
+        val entries = AiringScheduleRepository().getWeeklySchedule(
+            weekStart.toEpochSecond(),
+            weekEnd.toEpochSecond(),
+            includeAdult = schedulePrefs.showAdultContent().get(),
+        )
+
+        // Only consider episodes that aired within the last worker interval, so the same
+        // episode isn't re-checked (and the running average skewed) on every subsequent run.
+        val lastCheckTime = schedulePrefs.lastDelayCheckTime().get()
+        val windowStart = if (lastCheckTime > 0L) lastCheckTime else nowEpoch - 24 * 3600
+        return entries.filter { it.airingAt in windowStart..nowEpoch }
+    }
+
+    /**
+     * Queries the real source episode list for each aired entry's matching library anime and
+     * returns the learned (sourceId, delayMinutes) observations. Avoids re-fetching the same
+     * source within a single run and caps total source calls so large libraries can't make the
+     * background worker exceed its WorkManager window. This is a soft cap; the per-source
+     * observations are still written so the learning keeps improving over subsequent runs.
+     */
+    private suspend fun collectDelayObservations(
+        airedEntries: List<AiringScheduleEntry>,
+        libraryAnime: List<Anime>,
+    ): List<Pair<String, Long>> {
+        val sourceManager = Injekt.get<SourceManager>()
+        val observations = mutableListOf<Pair<String, Long>>()
+        val alreadyQueriedSources = mutableSetOf<Long>()
+        var sourceCallsThisRun = 0
+
+        for (entry in airedEntries) {
+            if (sourceCallsThisRun >= MAX_SOURCE_CALLS_PER_RUN) break
+            val matches = matchingLibraryAnime(entry, libraryAnime)
+            for (anime in matches) {
+                if (!alreadyQueriedSources.add(anime.source)) continue
+                if (sourceCallsThisRun >= MAX_SOURCE_CALLS_PER_RUN) break
+                sourceCallsThisRun++
+
+                observeUploadDelay(sourceManager, anime, entry)?.let { delayMinutes ->
+                    observations.add(anime.source.toString() to delayMinutes)
+                }
+            }
+        }
+        return observations
+    }
+
+    private fun matchingLibraryAnime(
+        entry: AiringScheduleEntry,
+        libraryAnime: List<Anime>,
+    ): List<Anime> {
+        val titleCandidates = listOfNotNull(
+            entry.titleUserPreferred,
+            entry.titleEnglish,
+            entry.titleRomaji,
+            entry.titleNative,
+        ).map { it.trim().lowercase() }.toSet()
+        return libraryAnime.filter { it.title.trim().lowercase() in titleCandidates }
+    }
+
+    /** Fetches [anime]'s real episode list from its source and returns a plausible delay in minutes, if any. */
+    private suspend fun observeUploadDelay(
+        sourceManager: SourceManager,
+        anime: Anime,
+        entry: AiringScheduleEntry,
+    ): Long? {
+        val source = sourceManager.get(anime.source) ?: return null
+        val episodes = runCatching { source.getEpisodeList(anime.toSAnime()) }.getOrNull() ?: return null
+        val matchingEpisode = episodes.firstOrNull { abs(it.episode_number - entry.episode) < 0.01f } ?: return null
+        val uploadDate = matchingEpisode.date_upload
+        if (uploadDate <= 0L) return null
+
+        val delayMinutes = (uploadDate / 1000L - entry.airingAt) / 60L
+        // Discard implausible outliers (source's clock/metadata far off, or the episode
+        // predates this air date entirely) rather than let them corrupt the running average.
+        return delayMinutes.takeIf { it in -60L..(24 * 60) }
+    }
+
+    companion object {
+        private const val WORK_NAME = "ScheduleRefreshWorker"
+        private const val MAX_SOURCE_CALLS_PER_RUN = 12
+
+        fun schedule(context: Context, interval: SchedulePreferences.UploadDelayInterval) {
+            val wm = WorkManager.getInstance(context)
+            // NEVER: user wants no background refresh at all. CUSTOM: the user supplies a fixed
+            // manual delay instead of an auto-learned one, so there is nothing for this worker
+            // to learn — cancel any existing periodic job rather than scheduling one.
+            if (
+                interval == SchedulePreferences.UploadDelayInterval.NEVER ||
+                interval == SchedulePreferences.UploadDelayInterval.CUSTOM
+            ) {
+                wm.cancelUniqueWork(WORK_NAME)
+                return
+            }
+            val minutes = when (interval) {
+                SchedulePreferences.UploadDelayInterval.THIRTY_MIN -> 30L
+                SchedulePreferences.UploadDelayInterval.ONE_HOUR -> 60L
+                SchedulePreferences.UploadDelayInterval.TWO_HOURS -> 120L
+                SchedulePreferences.UploadDelayInterval.SIX_HOURS -> 360L
+                SchedulePreferences.UploadDelayInterval.TWELVE_HOURS -> 720L
+                SchedulePreferences.UploadDelayInterval.NEVER,
+                SchedulePreferences.UploadDelayInterval.CUSTOM,
+                    -> return
+            }
+            val request = PeriodicWorkRequestBuilder<ScheduleRefreshWorker>(minutes, TimeUnit.MINUTES)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        // Explicitly does NOT require battery-not-low / device-idle, so this
+                        // still runs on a low battery or when the device is actively in use —
+                        // it is only gated on network availability. WorkManager may still defer
+                        // execution slightly under Doze regardless of the app's own
+                        // "unrestricted background battery usage" setting; that ceiling can only
+                        // be fully removed by running as a foreground service, which isn't
+                        // appropriate for a periodic background sync like this.
+                        .build(),
+                )
+                .build()
+            wm.enqueueUniquePeriodicWork(WORK_NAME, ExistingPeriodicWorkPolicy.UPDATE, request)
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+        }
+    }
+}

--- a/app/src/main/java/mihon/feature/airingschedule/UploadDelayTracker.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/UploadDelayTracker.kt
@@ -1,0 +1,103 @@
+package mihon.feature.airingschedule
+
+import android.util.Log
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import uy.kohesive.injekt.injectLazy
+
+/**
+ * Manages learned upload delay per source.
+ * A "delay" is how many minutes after AniList's official air time a source typically
+ * makes an episode available.  Negative values mean the source is early.
+ *
+ * Delays are stored as a JSON map: { "sourceId" : averageDelayMinutes }
+ */
+class UploadDelayTracker {
+
+    private val prefs: SchedulePreferences by injectLazy()
+    private val json: Json by injectLazy()
+
+    /** Returns all stored delays (sourceId → delay in minutes). */
+    fun getDelays(): Map<String, Long> {
+        val raw = prefs.sourceUploadDelays().get()
+        return try {
+            val obj = json.parseToJsonElement(raw) as? JsonObject ?: return emptyMap()
+            obj.entries.associate { (k, v) -> k to v.jsonPrimitive.long }
+        } catch (_: Exception) {
+            emptyMap()
+        }
+    }
+
+    /** Returns the stored delay for a single source, or null if unknown. */
+    fun getDelay(sourceId: String): Long? = getDelays()[sourceId]
+
+    /**
+     * Records a new data point for a source.
+     * [observedDelayMinutes] = time the episode appeared on the source minus AniList air time,
+     * expressed in minutes.  Uses an exponential moving average (α=0.4) to smooth samples.
+     */
+    fun recordObservation(sourceId: String, observedDelayMinutes: Long) {
+        val delays = getDelays().toMutableMap()
+        val prev = delays[sourceId]
+        val updated = if (prev == null) {
+            observedDelayMinutes
+        } else {
+            ((0.6 * prev) + (0.4 * observedDelayMinutes)).toLong()
+        }
+        delays[sourceId] = updated
+        saveDelays(delays)
+        Log.d("UploadDelayTracker", "Source $sourceId delay updated to ${updated}min")
+    }
+
+    /**
+     * Batch-records observations for multiple (sourceId, delayMinutes) pairs in a single
+     * read → update → write cycle, avoiding repeated disk I/O for each entry.
+     */
+    fun recordObservations(observations: List<Pair<String, Long>>) {
+        if (observations.isEmpty()) return
+        val delays = getDelays().toMutableMap()
+        for ((sourceId, observedDelayMinutes) in observations) {
+            val prev = delays[sourceId]
+            delays[sourceId] = if (prev == null) {
+                observedDelayMinutes
+            } else {
+                ((0.6 * prev) + (0.4 * observedDelayMinutes)).toLong()
+            }
+        }
+        saveDelays(delays)
+    }
+
+    /** Clears the stored delay for a source. */
+    fun clearDelay(sourceId: String) {
+        val delays = getDelays().toMutableMap()
+        delays.remove(sourceId)
+        saveDelays(delays)
+    }
+
+    /** Clears all stored delays. */
+    fun clearAllDelays() {
+        prefs.sourceUploadDelays().set("{}")
+    }
+
+    private fun saveDelays(delays: Map<String, Long>) {
+        val obj = buildJsonObject {
+            delays.forEach { (k, v) -> put(k, v) }
+        }
+        prefs.sourceUploadDelays().set(obj.toString())
+    }
+
+    companion object {
+        /**
+         * Converts a stored delay (minutes) to the expected airing timestamp.
+         * [anilistAirAt] is the Unix epoch in seconds from AniList.
+         * Returns the adjusted timestamp in seconds.
+         */
+        fun adjustedAirTime(anilistAirAt: Long, delayMinutes: Long): Long =
+            anilistAirAt + (delayMinutes * 60)
+    }
+}

--- a/app/src/main/java/mihon/feature/airingschedule/components/EpisodeBell.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/components/EpisodeBell.kt
@@ -1,0 +1,123 @@
+package mihon.feature.airingschedule.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.outlined.NotificationsNone
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/** How the user currently wants to be alerted about a show's episodes. */
+enum class BellNotifyState { NONE, ONCE, SERIES }
+
+private const val LONG_PRESS_DURATION_MS = 500L
+
+/**
+ * Per-anime notification bell shown on the Schedule tab.
+ *
+ * - A quick tap toggles a one-off alert for the next upcoming episode ([BellNotifyState.ONCE]).
+ * - Pressing and holding for 0.5 seconds toggles recurring alerts for every future episode until
+ *   the series finishes airing ([BellNotifyState.SERIES]).
+ *
+ * The bell is tinted relative to the current Material theme: idle uses a neutral surface tint,
+ * a single-episode alert uses a lightened complementary tone, and a series-wide alert uses the
+ * full-strength complementary tone so it stands out clearly from the app's primary color.
+ */
+@Composable
+fun EpisodeBell(
+    state: BellNotifyState,
+    onTap: () -> Unit,
+    onLongPress: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val pressProgressState = remember { mutableFloatStateOf(0f) }
+    val animatedProgress by animateFloatAsState(targetValue = pressProgressState.floatValue, label = "bellPressProgress")
+
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val neutralTint = onSurface.copy(alpha = 0.4f)
+    val onceTint = onSurface.copy(alpha = 0.85f)
+    val seriesTint = onSurface
+
+    val tint = when (state) {
+        BellNotifyState.NONE -> neutralTint
+        BellNotifyState.ONCE -> onceTint
+        BellNotifyState.SERIES -> seriesTint
+    }
+
+    Box(
+        modifier = modifier
+            .size(36.dp)
+            .pointerInput(onTap, onLongPress) {
+                coroutineScope {
+                    while (true) {
+                        awaitPointerEventScope {
+                            awaitFirstDown(pass = PointerEventPass.Main)
+                        }
+                        var longPressFired = false
+                        val progressJob = launch {
+                            val steps = 40
+                            val stepDelay = LONG_PRESS_DURATION_MS / steps
+                            for (i in 1..steps) {
+                                delay(stepDelay)
+                                pressProgressState.floatValue = i / steps.toFloat()
+                            }
+                            longPressFired = true
+                            onLongPress()
+                        }
+                        awaitPointerEventScope {
+                            waitForUpOrCancellation()
+                        }
+                        progressJob.cancel()
+                        pressProgressState.floatValue = 0f
+                        if (!longPressFired) {
+                            onTap()
+                        }
+                    }
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = if (state == BellNotifyState.NONE) Icons.Outlined.NotificationsNone else Icons.Filled.Notifications,
+            contentDescription = when (state) {
+                BellNotifyState.NONE -> "Notify me about this episode"
+                BellNotifyState.ONCE -> "Notifying for next episode only. Hold to notify every episode"
+                BellNotifyState.SERIES -> "Notifying every episode until the series finishes"
+            },
+            tint = tint,
+            modifier = Modifier.size(18.dp),
+        )
+        if (animatedProgress > 0f) {
+            Canvas(modifier = Modifier.size(30.dp)) {
+                val sweep = 360f * animatedProgress
+                drawArc(
+                    color = seriesTint,
+                    startAngle = -90f,
+                    sweepAngle = sweep,
+                    useCenter = false,
+                    style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/mihon/feature/airingschedule/components/ScheduleAnimeCard.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/components/ScheduleAnimeCard.kt
@@ -1,0 +1,362 @@
+package mihon.feature.airingschedule.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BookmarkAdd
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.NotificationsActive
+import androidx.compose.material.icons.outlined.NotificationsNone
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material3.Badge
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import mihon.feature.airingschedule.AiringScheduleEntry
+import mihon.feature.airingschedule.SchedulePreferences
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+private val timeFormatter24h = DateTimeFormatter.ofPattern("HH:mm")
+private val timeFormatter12h = DateTimeFormatter.ofPattern("h:mm a")
+
+@Composable
+fun ScheduleAnimeCard(
+    entry: AiringScheduleEntry,
+    titleLanguage: SchedulePreferences.TitleLanguage,
+    sourceDelays: Map<String, Long>,
+    manualDelayMinutes: Long?,
+    pinnedSourceIds: Set<String>,
+    isInLibrary: Boolean,
+    notifyState: BellNotifyState,
+    onSearchClick: (String) -> Unit,
+    onAddToLibraryClick: (String) -> Unit,
+    onToggleNotifyOnce: () -> Unit,
+    onToggleNotifySeries: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val title = entry.displayTitle(titleLanguage)
+
+    val matchedPinnedSource = remember(pinnedSourceIds, entry.titleUserPreferred) {
+        pinnedSourceIds.firstOrNull { sourceId ->
+            sourceId in sourceDelays.keys
+        }
+    }
+
+    val delayMinutes = manualDelayMinutes ?: matchedPinnedSource?.let { sourceDelays[it] }
+    val adjustedAirTime = if (delayMinutes != null) entry.airingAt + (delayMinutes * 60) else entry.airingAt
+    val hasAired = adjustedAirTime <= System.currentTimeMillis() / 1000L
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .clickable { onSearchClick(title) },
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+        ),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(12.dp)
+                .height(130.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            ScheduleAnimeCover(
+                imageUrl = entry.coverImageUrl,
+                title = title,
+                hasAired = hasAired,
+            )
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.SpaceBetween,
+            ) {
+                ScheduleAnimeInfo(
+                    title = title,
+                    isInLibrary = isInLibrary,
+                    airingAt = entry.airingAt,
+                    delayMinutes = delayMinutes,
+                    hasAired = hasAired,
+                    episode = entry.episode,
+                    totalEpisodes = entry.totalEpisodes,
+                    format = entry.format,
+                    score = entry.averageScore,
+                )
+
+                ScheduleAnimeActions(
+                    isInLibrary = isInLibrary,
+                    hasAired = hasAired,
+                    notifyState = notifyState,
+                    onSearchClick = { onSearchClick(title) },
+                    onAddToLibraryClick = { onAddToLibraryClick(title) },
+                    onToggleNotifyOnce = onToggleNotifyOnce,
+                    onToggleNotifySeries = onToggleNotifySeries,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScheduleAnimeCover(
+    imageUrl: String?,
+    title: String,
+    hasAired: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .size(width = 90.dp, height = 130.dp)
+            .clip(RoundedCornerShape(8.dp)),
+    ) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = title,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+        )
+        if (hasAired) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.4f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Badge(
+                    containerColor = MaterialTheme.colorScheme.tertiary,
+                    contentColor = MaterialTheme.colorScheme.onTertiary,
+                ) {
+                    Text(
+                        text = "Aired",
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(horizontal = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScheduleAnimeInfo(
+    title: String,
+    isInLibrary: Boolean,
+    airingAt: Long,
+    delayMinutes: Long?,
+    hasAired: Boolean,
+    episode: Int,
+    totalEpisodes: Int?,
+    format: String?,
+    score: Int?,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            color = if (isInLibrary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+        )
+
+        AirTimeBadgeRow(
+            hasAired = hasAired,
+            airingAt = airingAt,
+            delayMinutes = delayMinutes,
+            episode = episode,
+            totalEpisodes = totalEpisodes,
+        )
+
+        ScheduleAnimeMetaRow(
+            format = format,
+            score = score,
+        )
+    }
+}
+
+@Composable
+private fun AirTimeBadgeRow(
+    hasAired: Boolean,
+    airingAt: Long,
+    delayMinutes: Long?,
+    episode: Int,
+    totalEpisodes: Int?,
+) {
+    val zone = ZoneId.systemDefault()
+    val airDateTime = ZonedDateTime.ofInstant(Instant.ofEpochSecond(airingAt), zone)
+    val use24h = android.text.format.DateFormat.is24HourFormat(androidx.compose.ui.platform.LocalContext.current)
+    val timeStr = airDateTime.format(if (use24h) timeFormatter24h else timeFormatter12h)
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Badge(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ) {
+            Text(
+                text = "Ep $episode${totalEpisodes?.let { "/$it" } ?: ""}",
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(horizontal = 4.dp),
+            )
+        }
+
+        Text(
+            text = timeStr,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        if (!hasAired) {
+            val adjustedAirTime = if (delayMinutes != null) airingAt + (delayMinutes * 60) else airingAt
+            val countdown = formatCountdown(adjustedAirTime)
+            if (countdown != null) {
+                Text(
+                    text = "• $countdown",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScheduleAnimeMetaRow(
+    format: String?,
+    score: Int?,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        format?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        score?.let {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                Icon(
+                    imageVector = Icons.Outlined.Star,
+                    contentDescription = null,
+                    modifier = Modifier.size(12.dp),
+                    tint = Color(0xFFFFB300),
+                )
+                Text(
+                    text = "$it%",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScheduleAnimeActions(
+    isInLibrary: Boolean,
+    hasAired: Boolean,
+    notifyState: BellNotifyState,
+    onSearchClick: () -> Unit,
+    onAddToLibraryClick: () -> Unit,
+    onToggleNotifyOnce: () -> Unit,
+    onToggleNotifySeries: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (!isInLibrary) {
+            IconButton(onClick = onAddToLibraryClick) {
+                Icon(
+                    imageVector = Icons.Outlined.BookmarkAdd,
+                    contentDescription = stringResource(MR.strings.action_add),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        } else {
+            IconButton(onClick = onSearchClick) {
+                Icon(
+                    imageVector = Icons.Outlined.PlayArrow,
+                    contentDescription = stringResource(MR.strings.action_play),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+
+        IconButton(onClick = onToggleNotifyOnce) {
+            Icon(
+                imageVector = when (notifyState) {
+                    BellNotifyState.ONCE -> Icons.Outlined.NotificationsActive
+                    else -> Icons.Outlined.NotificationsNone
+                },
+                contentDescription = null,
+                tint = if (notifyState == BellNotifyState.ONCE) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        IconButton(onClick = onToggleNotifySeries) {
+            Icon(
+                imageVector = when (notifyState) {
+                    BellNotifyState.SERIES -> Icons.Outlined.NotificationsActive
+                    else -> Icons.Outlined.Notifications
+                },
+                contentDescription = null,
+                tint = if (notifyState == BellNotifyState.SERIES) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun formatCountdown(airingAt: Long): String? {
+    val now = System.currentTimeMillis() / 1000L
+    val diff = airingAt - now
+    if (diff <= 0) return null
+
+    val days = diff / 86400
+    val hours = (diff % 86400) / 3600
+    val minutes = (diff % 3600) / 60
+
+    return when {
+        days > 0 -> "${days}d ${hours}h"
+        hours > 0 -> "${hours}h ${minutes}m"
+        else -> "${minutes}m"
+    }
+}

--- a/app/src/main/java/mihon/feature/airingschedule/notification/ScheduleAlarmReceiver.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/notification/ScheduleAlarmReceiver.kt
@@ -1,0 +1,115 @@
+package mihon.feature.airingschedule.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import androidx.core.app.NotificationCompat
+import androidx.core.graphics.drawable.toBitmap
+import coil3.asDrawable
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.ui.main.MainActivity
+import eu.kanade.tachiyomi.util.system.notify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Fires the actual system notification once an alarm scheduled by [ScheduleNotifications]
+ * reaches its trigger time. Styled to match the app's own notification look (accent color,
+ * app icon, cover art as the large icon) rather than a bare system default notification.
+ */
+class ScheduleAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val mediaId = intent.getIntExtra(EXTRA_MEDIA_ID, -1)
+        val episode = intent.getIntExtra(EXTRA_EPISODE, -1)
+        val title = intent.getStringExtra(EXTRA_TITLE) ?: return
+        val coverUrl = intent.getStringExtra(EXTRA_COVER_URL)
+        if (mediaId == -1 || episode == -1) return
+
+        // Remove the alarm key from the scheduled set first, before the async notification work.
+        // All key-set mutations go through ScheduleNotifications so they are serialized.
+        ScheduleNotifications.removeAlarmKey(mediaId, episode)
+
+        // Cover-art loading is async (network/disk); use goAsync() so the receiver's process
+        // isn't killed before the notification is actually posted. goAsync() only grants a
+        // short (~10s) execution window before the OS may kill the process, so the cover
+        // fetch is capped well under that and the notification is always posted — with or
+        // without the cover — inside a try/finally so pendingResult.finish() is never skipped.
+        val pendingResult = goAsync()
+        val appContext = context.applicationContext
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val coverBitmap = coverUrl?.let {
+                    withTimeoutOrNull(COVER_LOAD_TIMEOUT_MS) { loadCoverBitmap(appContext, it) }
+                }
+                postNotification(appContext, mediaId, episode, title, coverBitmap)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private suspend fun loadCoverBitmap(context: Context, url: String): Bitmap? = runCatching {
+        val request = ImageRequest.Builder(context).data(url).build()
+        context.imageLoader.execute(request).image
+            ?.asDrawable(context.resources)
+            ?.toBitmap()
+    }.getOrNull()
+
+    private fun postNotification(
+        context: Context,
+        mediaId: Int,
+        episode: Int,
+        title: String,
+        coverBitmap: Bitmap?,
+    ) {
+        val contentIntent = Intent(context, MainActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            putExtra(MainActivity.INTENT_SEARCH_QUERY, title)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingContentIntent = android.app.PendingIntent.getActivity(
+            context,
+            ScheduleNotifications.requestCode(mediaId, episode),
+            contentIntent,
+            android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val contentText = context.getString(R.string.notification_episode_aired, episode)
+
+        // Use bitmasking instead of kotlin.math.abs to safely strip the sign bit.
+        // abs(Int.MIN_VALUE) overflows back to Int.MIN_VALUE, so bitmask is the safe approach.
+        val notificationId = Notifications.ID_AIRING_SCHEDULE_BASE -
+            ((ScheduleNotifications.requestCode(mediaId, episode) and Int.MAX_VALUE) % 10000)
+
+        runCatching {
+            context.notify(notificationId, Notifications.CHANNEL_AIRING_SCHEDULE) {
+                setSmallIcon(R.drawable.ic_komikku)
+                setContentTitle(title)
+                setContentText(contentText)
+                setStyle(NotificationCompat.BigTextStyle().bigText(contentText))
+                coverBitmap?.let { setLargeIcon(it) }
+                setPriority(NotificationCompat.PRIORITY_HIGH)
+                setCategory(NotificationCompat.CATEGORY_REMINDER)
+                setAutoCancel(true)
+                setContentIntent(pendingContentIntent)
+            }
+        }
+    }
+
+    companion object {
+        const val EXTRA_MEDIA_ID = "media_id"
+        const val EXTRA_EPISODE = "episode"
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_COVER_URL = "cover_url"
+        private const val COVER_LOAD_TIMEOUT_MS = 6_000L
+    }
+}

--- a/app/src/main/java/mihon/feature/airingschedule/notification/ScheduleNotifications.kt
+++ b/app/src/main/java/mihon/feature/airingschedule/notification/ScheduleNotifications.kt
@@ -1,0 +1,138 @@
+package mihon.feature.airingschedule.notification
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.runBlocking
+import mihon.feature.airingschedule.AiringScheduleEntry
+import mihon.feature.airingschedule.SchedulePreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Schedules/cancels the local alarms that back the per-anime "notify me" bell on the
+ * Schedule tab. Notifications are delivered by [ScheduleAlarmReceiver] at episode air time.
+ */
+object ScheduleNotifications {
+
+    private val schedulePreferences: SchedulePreferences by lazy { Injekt.get() }
+
+    // The persisted "scheduled alarm keys" set is read-modified-written from multiple
+    // independent callers (UI toggle taps, the weekly refresh worker, and the alarm receiver
+    // itself when an alarm fires) which can race and lose updates if not serialized. All
+    // mutating access goes through this mutex.
+    private val keysMutex = Mutex()
+
+    private inline fun <T> withKeysLock(crossinline block: () -> T): T = runBlocking { keysMutex.withLock { block() } }
+
+    fun alarmKey(mediaId: Int, episode: Int): String = "$mediaId:$episode"
+
+    fun requestCode(mediaId: Int, episode: Int): Int = alarmKey(mediaId, episode).hashCode()
+
+    /**
+     * Whether the app is currently allowed to schedule *exact* alarms. On Android 12
+     * (API 31) this permission is auto-granted; on Android 13+ it can be revoked by the
+     * user or the system, so callers should check this and, if false, prompt the user via
+     * [requestExactAlarmPermission] so the schedule bell fires at the precise air time
+     * instead of being deferred by battery-optimization/Doze batching windows.
+     */
+    fun canScheduleExactAlarms(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return false
+        return alarmManager.canScheduleExactAlarms()
+    }
+
+    /** Opens the system settings screen where the user can grant the exact-alarm permission. */
+    fun requestExactAlarmPermission(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        runCatching {
+            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                data = Uri.parse("package:${context.packageName}")
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            context.startActivity(intent)
+        }
+    }
+
+    /**
+     * Ensures an alarm is scheduled for [entry] if it hasn't aired yet and isn't already
+     * pending. Returns true if an alarm is now scheduled (or already was), false if the
+     * episode has already aired and nothing was scheduled — callers must not persist a
+     * "notify" preference in that case since no alarm backs it.
+     */
+    fun ensureScheduled(context: Context, entry: AiringScheduleEntry): Boolean = withKeysLock {
+        if (entry.hasAired()) return@withKeysLock false
+        val key = alarmKey(entry.mediaId, entry.episode)
+        val scheduled = schedulePreferences.scheduledAlarmKeys().get()
+        if (key in scheduled) return@withKeysLock true
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+            ?: return@withKeysLock false
+        val intent = Intent(context, ScheduleAlarmReceiver::class.java).apply {
+            putExtra(ScheduleAlarmReceiver.EXTRA_MEDIA_ID, entry.mediaId)
+            putExtra(ScheduleAlarmReceiver.EXTRA_EPISODE, entry.episode)
+            putExtra(ScheduleAlarmReceiver.EXTRA_TITLE, entry.titleUserPreferred)
+            putExtra(ScheduleAlarmReceiver.EXTRA_COVER_URL, entry.coverImageUrl)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            requestCode(entry.mediaId, entry.episode),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val triggerAtMillis = entry.airingAt * 1000L
+        runCatching {
+            if (canScheduleExactAlarms(context)) {
+                // Fires at the precise millisecond even in Doze/App Standby, regardless of
+                // whether the user has disallowed background battery usage for the app —
+                // exact RTC_WAKEUP alarms are not subject to that restriction.
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+            } else {
+                // No exact-alarm permission granted (Android 13+ user/system revoked it) —
+                // fall back to an inexact alarm; timing may drift under Doze.
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+            }
+            // Only persist the key after a successful registration so that a future call
+            // can retry if the platform rejected the alarm. Re-read the current set under
+            // the lock rather than reusing the stale `scheduled` snapshot, since another
+            // caller could have mutated it while the alarm was being registered.
+            val current = schedulePreferences.scheduledAlarmKeys().get()
+            schedulePreferences.scheduledAlarmKeys().set(current + key)
+            true
+        }.getOrDefault(false)
+    }
+
+    /** Cancels a single previously-scheduled alarm for [entry], if any. */
+    fun cancel(context: Context, entry: AiringScheduleEntry) = withKeysLock {
+        val key = alarmKey(entry.mediaId, entry.episode)
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+            ?: return@withKeysLock
+        val intent = Intent(context, ScheduleAlarmReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            requestCode(entry.mediaId, entry.episode),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        alarmManager.cancel(pendingIntent)
+        schedulePreferences.scheduledAlarmKeys().set(schedulePreferences.scheduledAlarmKeys().get() - key)
+    }
+
+    /** Cancels every alarm currently scheduled for episodes belonging to [mediaId]. */
+    fun cancelAllForMedia(context: Context, mediaId: Int, entries: List<AiringScheduleEntry>) {
+        entries.filter { it.mediaId == mediaId }.forEach { cancel(context, it) }
+    }
+
+    /** Removes the persisted alarm key for an already-fired alarm (receiver path). */
+    fun removeAlarmKey(mediaId: Int, episode: Int) = withKeysLock {
+        val key = alarmKey(mediaId, episode)
+        schedulePreferences.scheduledAlarmKeys().set(schedulePreferences.scheduledAlarmKeys().get() - key)
+    }
+}

--- a/app/src/main/java/mihon/feature/upcoming/UpcomingScreen.kt
+++ b/app/src/main/java/mihon/feature/upcoming/UpcomingScreen.kt
@@ -28,6 +28,7 @@ class UpcomingScreen : Screen() {
             hideUpdatingMangas = screenModel::hideUpdatingMangas,
             isPredictReleaseDate = ANIME_OUTSIDE_RELEASE_PERIOD in screenModel.restriction,
             // KMK <--
+            useScaffold = true,
         )
     }
 }

--- a/app/src/main/java/mihon/feature/upcoming/UpcomingScreenContent.kt
+++ b/app/src/main/java/mihon/feature/upcoming/UpcomingScreenContent.kt
@@ -1,5 +1,6 @@
 package mihon.feature.upcoming
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.components.AppBar
@@ -56,6 +58,9 @@ fun UpcomingScreenContent(
     isPredictReleaseDate: Boolean,
     // KMK <--
     modifier: Modifier = Modifier,
+    // Unified Hub -->
+    useScaffold: Boolean = false,
+    // <-- Unified Hub
 ) {
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
@@ -74,53 +79,63 @@ fun UpcomingScreenContent(
             }
         }
     }
-    Scaffold(
-        topBar = {
-            UpcomingToolbar(
-                // KMK -->
-                state.isShowingUpdatingMangas,
-                showUpdatingMangas = showUpdatingMangas,
-                hideUpdatingMangas = hideUpdatingMangas,
-                isPredictReleaseDate = isPredictReleaseDate,
-                // KMK <--
-            )
-        },
-        modifier = modifier,
-    ) { paddingValues ->
+
+    val content: @Composable (PaddingValues) -> Unit = { paddingValues ->
         // KMK -->
         if (isLoading) {
             LoadingScreen(modifier = Modifier.padding(paddingValues))
-            return@Scaffold
-        }
-        // KMK <--
-        if (isTabletUi()) {
-            UpcomingScreenLargeImpl(
-                listState = listState,
-                items = items,
-                events = events,
-                paddingValues = paddingValues,
-                selectedYearMonth = state.selectedYearMonth,
-                setSelectedYearMonth = setSelectedYearMonth,
-                onClickDay = { onClickDay(it, 0) },
-                onClickUpcoming = onClickUpcoming,
-                // KMK -->
-                state.isShowingUpdatingMangas,
-                // KMK <--
-            )
         } else {
-            UpcomingScreenSmallImpl(
-                listState = listState,
-                items = items,
-                events = events,
-                paddingValues = paddingValues,
-                selectedYearMonth = state.selectedYearMonth,
-                setSelectedYearMonth = setSelectedYearMonth,
-                onClickDay = { onClickDay(it, 1) },
-                onClickUpcoming = onClickUpcoming,
-                // KMK -->
-                state.isShowingUpdatingMangas,
-                // KMK <--
-            )
+            // KMK <--
+            if (isTabletUi()) {
+                UpcomingScreenLargeImpl(
+                    listState = listState,
+                    items = items,
+                    events = events,
+                    paddingValues = paddingValues,
+                    selectedYearMonth = state.selectedYearMonth,
+                    setSelectedYearMonth = setSelectedYearMonth,
+                    onClickDay = { onClickDay(it, 0) },
+                    onClickUpcoming = onClickUpcoming,
+                    // KMK -->
+                    state.isShowingUpdatingMangas,
+                    // KMK <--
+                )
+            } else {
+                UpcomingScreenSmallImpl(
+                    listState = listState,
+                    items = items,
+                    events = events,
+                    paddingValues = paddingValues,
+                    selectedYearMonth = state.selectedYearMonth,
+                    setSelectedYearMonth = setSelectedYearMonth,
+                    onClickDay = { onClickDay(it, 1) },
+                    onClickUpcoming = onClickUpcoming,
+                    // KMK -->
+                    state.isShowingUpdatingMangas,
+                    // KMK <--
+                )
+            }
+        }
+    }
+
+    if (useScaffold) {
+        Scaffold(
+            topBar = {
+                UpcomingToolbar(
+                    // KMK -->
+                    state.isShowingUpdatingMangas,
+                    showUpdatingMangas = showUpdatingMangas,
+                    hideUpdatingMangas = hideUpdatingMangas,
+                    isPredictReleaseDate = isPredictReleaseDate,
+                    // KMK <--
+                )
+            },
+            modifier = modifier,
+            content = content,
+        )
+    } else {
+        Box(modifier = modifier) {
+            content(PaddingValues(0.dp))
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <!-- unpublished -> 4C1B4D71 / published -> F033F567 -->
     <string name="app_cast_id" translatable="false">null</string>
+    <string name="notification_episode_aired">Episode %1$d just aired</string>
 </resources>

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -30,6 +30,13 @@ class CloudflareInterceptor(
     private val executor = ContextCompat.getMainExecutor(context)
 
     override fun shouldIntercept(response: Response): Boolean {
+        // Never attempt a WebView-based bypass for known JSON/data APIs. These endpoints are
+        // never rendered in a browser, so a Cloudflare interactive challenge can't be solved by
+        // loading them in a WebView (the JS challenge redirects/POST bodies don't carry over).
+        // Doing so previously caused unrelated transient errors (e.g. rate limiting) from these
+        // APIs to be misreported as "Failed to bypass Cloudflare".
+        if (response.request.url.host in NON_INTERACTIVE_API_HOSTS) return false
+
         // Check if Cloudflare anti-bot is on
         return response.code in ERROR_CODES && response.header("Server") in SERVER_CHECK
     }
@@ -138,5 +145,9 @@ class CloudflareInterceptor(
 private val ERROR_CODES = listOf(403, 503)
 private val SERVER_CHECK = arrayOf("cloudflare-nginx", "cloudflare")
 private val COOKIE_NAMES = listOf("cf_clearance")
+
+// Data APIs that are consumed directly (never loaded in a browser) and therefore must not be
+// routed through the WebView-based Cloudflare bypass flow.
+private val NON_INTERACTIVE_API_HOSTS = setOf("graphql.anilist.co")
 
 private class CloudflareBypassException : Exception()

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -7,7 +7,7 @@
     <string name="not_selected">Not selected</string>
     <string name="action_menu_overflow_description">More options</string>
     <string name="action_bar_up_description">Navigate up</string>
-    <string name="app_name" translatable="false">Aniyomi</string>
+    <string name="app_name" translatable="false">Anikku</string>
     <string name="name">Name</string>
     <string name="categories">Categories</string>
     <string name="manga">Manga</string>
@@ -664,7 +664,7 @@
     <string name="information_empty_repos">You have no repos set.</string>
     <string name="action_add_repo">Add repo</string>
     <string name="label_add_repo_input">Repo URL</string>
-    <string name="action_add_repo_message">Add additional repos to Aniyomi. This should be a URL that ends with \"index.min.json\".</string>
+    <string name="action_add_repo_message">Add additional repos to Anikku. This should be a URL that ends with \"index.min.json\".</string>
     <string name="error_repo_exists">This repo already exists!</string>
     <string name="action_delete_repo">Delete repo</string>
     <string name="invalid_repo_name">Invalid repo URL</string>
@@ -1187,7 +1187,7 @@
     <string name="episodes">Episodes</string>
     <string name="backup_settings_warning">Warning: Backing up settings will store your track passwords as well, do not share this backup file!</string>
     <string name="label_manga_library">Manga</string>
-    <string name="label_anime_library">Anime</string>
+    <string name="label_anime_library">Library</string>
     <string name="label_anime">Anime</string>
     <string name="label_manga">Manga</string>
     <string name="label_recent_anime_updates">Anime Updates</string>
@@ -1202,7 +1202,7 @@
     <string name="pref_bottom_nav_no_updates">Move Updates to the More tab</string>
     <string name="pref_bottom_nav_no_manga">Move Manga to the More tab</string>
     <string name="pref_bottom_nav_no_browse">Move Browse to the More tab</string>
-    <string name="unlock_app_title">Unlock Aniyomi</string>
+    <string name="unlock_app_title">Unlock Anikku</string>
     <string name="action_filter_unseen">Unseen</string>
     <string name="action_global_manga_search">Global Manga Search</string>
     <string name="action_global_anime_search">Global Anime Search</string>
@@ -1322,7 +1322,7 @@
     <string name="episode_progress_no_total">Progress: %1$s</string>
     <string name="recent_anime_time">Ep. %1$s - %2$s</string>
     <string name="download_insufficient_space">Couldn\'t download due to low storage space</string>
-    <string name="download_queue_size_warning">Warning: large bulk downloads may lead to sources becoming slower and/or blocking Aniyomi. Tap to learn more.</string>
+    <string name="download_queue_size_warning">Warning: large bulk downloads may lead to sources becoming slower and/or blocking Anikku. Tap to learn more.</string>
     <string name="video_list_empty_error">No video found</string>
     <string name="notification_new_episodes">New episodes found</string>
     <string name="information_no_recent_anime">Nothing watched recently</string>
@@ -1380,7 +1380,29 @@
     <string name="unseen">Unseen</string>
     <string name="label_manga_extension_repos">Manga extension repos</string>
     <string name="label_anime_extension_repos">Anime extension repos</string>
-    <string name="onboarding_storage_action_create_folder">Create default Aniyomi folder</string>
+    <string name="onboarding_storage_action_create_folder">Create default Anikku folder</string>
     <string name="download_speed_limit">Chapter download speed limit</string>
     <string name="download_speed_limit_hint">Set to 0 to disable the speed limit.</string>
+
+    <!-- Airing Schedule -->
+    <string name="information_no_airing_today">No anime airing today</string>
+    <string name="label_airing_schedule">Airing Schedule</string>
+    <string name="pref_category_schedule">Schedule</string>
+    <string name="pref_category_schedule_summary">Weekly airing schedule from AniList</string>
+    <string name="pref_schedule_sources_title">Favorite Sources</string>
+    <string name="pref_schedule_favorite_sources">Favorite sources</string>
+    <string name="pref_schedule_favorite_sources_summary">Select the sources used when searching anime from the schedule</string>
+    <string name="pref_schedule_show_only_favorites">Filter by favorite sources</string>
+    <string name="pref_schedule_show_only_favorites_summary">Show only schedule entries searchable in your selected favorite sources</string>
+    <string name="pref_schedule_about_title">About</string>
+    <string name="pref_schedule_about_info">The airing schedule is powered by AniList. Tap the search icon on any anime to find it in your installed sources.</string>
+    <string name="pref_bottom_nav_no_schedule">Move Schedule to the More tab</string>
+    <string name="pref_schedule_auto_refresh_group">Auto Refresh</string>
+    <string name="pref_schedule_upload_delay_group">Upload Delay Tracking</string>
+    <string name="pref_schedule_display_group">Display</string>
+    <string name="cd_refresh_schedule">Refresh schedule</string>
+    <string name="cd_schedule_settings">Schedule settings</string>
+    <string name="schedule_error_title">Unable to load schedule</string>
+    <string name="pref_bottom_nav_no_feed">Move Feed to the More tab</string>
+    <string name="label_feed">Feed</string>
 </resources>


### PR DESCRIPTION
The new Schedule (accessed via 'Updates' calendar) merges a global AniList feed with local Library updates. It features smart delay tracking that learns when episodes upload to your pinned sources and provides precision alerts through alarms.
Pressing on the calendar/globe lets you switch between the usual 'Smart Updates' screen and the new 'AniList Airing Schedule' screen.
Superseeds #264.

## Image 1:
<img width="1080" height="2223" alt="image" src="https://github.com/user-attachments/assets/0abe6a71-b5df-4926-ace8-913030e01b4e" />

## Image 2:
<img width="1080" height="2223" alt="image" src="https://github.com/user-attachments/assets/c389c18f-045f-4f28-bb26-9536e697bc7b" />

## Image 3:
<img width="1080" height="2223" alt="image" src="https://github.com/user-attachments/assets/3748bcf9-f4d2-4915-8a0d-48f37b0de437" />


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/anikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Introduce an AniList-powered airing schedule hub alongside the existing Smart Updates calendar, with configurable navigation, preferences, and notification support.

New Features:
- Add an AniList Airing Schedule tab accessible from the Updates calendar, showing a week view of upcoming episodes with day tabs and anime cards.
- Provide schedule-specific settings for data source selection, auto-refresh, upload delay tracking, title language, adult content visibility, and notifications.
- Implement upload delay tracking and background workers to learn per-source episode upload offsets and periodically refresh schedule data.
- Enable per-series and per-episode notifications with exact alarm support, including a new airing schedule notification channel and alarm receiver.
- Allow switching between global AniList schedule and local Smart Updates view within the same hub, reusing the upcoming screen content.

Enhancements:
- Adjust navigation styles and tab indices to incorporate the new Schedule tab and optional relocation of tabs to the More section.
- Improve Cloudflare interceptor behavior by exempting AniList GraphQL API from WebView-based bypass attempts to avoid misreported errors.
- Default the bottom navigation style to move the new Schedule tab into the More section on first run.
- Update app branding strings from Aniyomi to Anikku and tweak some label text such as the anime library name and feed/schedule entries.

Build:
- Request SCHEDULE_EXACT_ALARM permission in the manifest to support precise airing schedule alerts.
- Register the schedule alarm broadcast receiver and ensure the track login activity uses singleTask launch mode.