### PR TITLE
feat(player): hold right third of screen for 2x fast-forward

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsPlayerScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/PlayerSettingsPlayerScreen.kt
@@ -99,6 +99,7 @@ object PlayerSettingsPlayerScreen : SearchableSettings {
     @Composable
     private fun getControlsGroup(playerPreferences: PlayerPreferences): Preference.PreferenceGroup {
         val allowGestures = playerPreferences.allowGestures()
+        val holdSpeedForward = playerPreferences.holdSpeedForward()
         val showLoading = playerPreferences.showLoadingCircle()
         val showChapter = playerPreferences.showCurrentChapter()
         val rememberPlayerBrightness = playerPreferences.rememberPlayerBrightness()
@@ -110,6 +111,17 @@ object PlayerSettingsPlayerScreen : SearchableSettings {
                 Preference.PreferenceItem.SwitchPreference(
                     pref = allowGestures,
                     title = stringResource(MR.strings.pref_controls_allow_gestures_in_panels),
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    pref = holdSpeedForward,
+                    title = stringResource(MR.strings.pref_hold_speed_forward),
+                    entries = persistentMapOf(
+                        2.0F to "2x",
+                        3.0F to "3x",
+                        4.0F to "4x",
+                        5.0F to "5x",
+                        6.0F to "6x",
+                    ),
                 ),
                 Preference.PreferenceItem.SwitchPreference(
                     pref = showLoading,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerEnums.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerEnums.kt
@@ -125,7 +125,7 @@ sealed class Dialogs {
 
 sealed class PlayerUpdates {
     data object None : PlayerUpdates()
-    data object DoubleSpeed : PlayerUpdates()
+    data class DoubleSpeed(val speed: Float) : PlayerUpdates()
     data object AspectRatio : PlayerUpdates()
     data class ShowText(val value: String) : PlayerUpdates()
     data class ShowTextResource(val textResource: StringResource) : PlayerUpdates()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
@@ -85,6 +85,7 @@ fun GestureHandler(
 
     val panelShown by viewModel.panelShown.collectAsState()
     val allowGesturesInPanels by playerPreferences.allowGestures().collectAsState()
+    val holdSpeedForward by playerPreferences.holdSpeedForward().collectAsState()
     val duration by viewModel.duration.collectAsState()
     val position by viewModel.pos.collectAsState()
     val controlsShown by viewModel.controlsShown.collectAsState()
@@ -119,7 +120,7 @@ fun GestureHandler(
             .fillMaxSize()
             .windowInsetsPadding(WindowInsets.safeGestures)
             .pointerInput(Unit) {
-                val originalSpeed = viewModel.playbackSpeed.value
+                var originalSpeed = viewModel.playbackSpeed.value
                 detectTapGestures(
                     onTap = {
                         if (controlsShown) viewModel.hideControls() else viewModel.showControls()
@@ -169,7 +170,15 @@ fun GestureHandler(
                     },
                     onLongPress = {
                         if (areControlsLocked) return@detectTapGestures
-                        if (!isLongPressing) {
+                        if (it.x > size.width * 2 / 3 && !isLongPressing && !viewModel.paused.value) {
+                            // Hold right third: 2x forward speed
+                            originalSpeed = viewModel.playbackSpeed.value
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            isLongPressing = true
+                            MPVLib.setPropertyDouble("speed", holdSpeedForward.toDouble())
+                            viewModel.playerUpdate.update { PlayerUpdates.DoubleSpeed(holdSpeedForward) }
+                        } else if (!isLongPressing) {
+                            // Hold left/center (or right third while paused): screenshot
                             haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                             isLongPressing = true
                             viewModel.pause()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -69,6 +69,7 @@ import eu.kanade.tachiyomi.ui.player.cast.components.CastSheet
 import eu.kanade.tachiyomi.ui.player.controls.components.BrightnessOverlay
 import eu.kanade.tachiyomi.ui.player.controls.components.BrightnessSlider
 import eu.kanade.tachiyomi.ui.player.controls.components.ControlsButton
+import eu.kanade.tachiyomi.ui.player.controls.components.DoubleSpeedPlayerUpdate
 import eu.kanade.tachiyomi.ui.player.controls.components.SeekbarWithTimers
 import eu.kanade.tachiyomi.ui.player.controls.components.TextPlayerUpdate
 import eu.kanade.tachiyomi.ui.player.controls.components.VolumeSlider
@@ -303,7 +304,7 @@ fun PlayerControls(
                     },
                 ) {
                     when (currentPlayerUpdate) {
-                        // is PlayerUpdates.DoubleSpeed -> DoubleSpeedPlayerUpdate()
+                        is PlayerUpdates.DoubleSpeed -> DoubleSpeedPlayerUpdate((currentPlayerUpdate as PlayerUpdates.DoubleSpeed).speed)
                         is PlayerUpdates.AspectRatio -> TextPlayerUpdate(stringResource(aspectRatio.titleRes))
                         is PlayerUpdates.ShowText -> TextPlayerUpdate(
                             (currentPlayerUpdate as PlayerUpdates.ShowText).value,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/PlayerUpdates.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/PlayerUpdates.kt
@@ -56,3 +56,13 @@ fun TextPlayerUpdate(
         Text(text)
     }
 }
+
+@Composable
+fun DoubleSpeedPlayerUpdate(
+    speed: Float,
+    modifier: Modifier = Modifier,
+) {
+    PlayerUpdate(modifier) {
+        Text("${speed}x", fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/PlayerPreferences.kt
@@ -21,6 +21,7 @@ class PlayerPreferences(
     // Controls
 
     fun allowGestures() = preferenceStore.getBoolean("pref_allow_gestures_in_panels", false)
+    fun holdSpeedForward() = preferenceStore.getFloat("pref_hold_speed_forward", 2.0F)
     fun showLoadingCircle() = preferenceStore.getBoolean("pref_show_loading", true)
     fun showCurrentChapter() = preferenceStore.getBoolean("pref_show_current_chapter", true)
     fun rememberPlayerBrightness() = preferenceStore.getBoolean("pref_remember_brightness", false)

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -203,6 +203,7 @@
 
     <string name="pref_category_controls">Controls</string>
     <string name="pref_controls_allow_gestures_in_panels">Allow gesture in panels</string>
+    <string name="pref_hold_speed_forward">Hold-to-fast-forward speed</string>
     <string name="pref_controls_show_loading">Show loading circle</string>
     <string name="pref_controls_show_chapter_indicator">Show current chapter indicator</string>
     <string name="pref_controls_show_chapter_indicator_info">Only appears if the video has chapters</string>


### PR DESCRIPTION
## Summary

- **Hold right third of the player screen** → playback speeds up to 2x with a "2x" badge overlay; releasing restores the original speed
- **Hold left/center** → still triggers the screenshot sheet (set-as-cover/share/save)
- Reactivates the existing `DoubleSpeed` `PlayerUpdates` enum and adds a `DoubleSpeedPlayerUpdate` badge composable that were left dead after the screenshot refactor (PR #1834)

This addresses community requests for a YouTube-style hold-to-fast-forward gesture (Issues #192, #254, PR #233).

### How it works

The `onLongPress` handler in `GestureHandler.kt` now checks the x-coordinate of the press:
- If `x > width * 3/5` (right third): captures the current playback speed, sets MPV `speed` to `2.0`, shows the `DoubleSpeed` badge
- Otherwise (left/center): pauses and opens the screenshot sheet (existing behavior)

On press release (`tryAwaitRelease`), if 2x was active, the speed is reset to the captured `originalSpeed` and the badge is cleared.

#### Test plan

- [x] Build passes (`./gradlew :app:assembleDebug`)
- [x] Verified on emulator: long-press right third fires `onLongPress`, sets MPV speed to 2.0, shows "2x" badge, resets to 1.0 on release
- [ ] Manual test on physical device: hold right third → 2x speed, release → normal speed
- [ ] Manual test on physical device: hold left/center → screenshot sheet appears
- [ ] Verify speed resets correctly when the player was already at a non-1.0x speed before the hold

## Summary by Sourcery

Add configurable hold-to-fast-forward controls to the player while retaining existing screenshot gestures.

New Features:
- Add configurable hold-to-fast-forward playback speeds from 2x through 6x.
- Show a playback-speed badge while fast-forward mode is active.

Enhancements:
- Restore right-side long-press fast-forward behavior while preserving screenshot capture for other long-press areas and paused playback.