### PR TITLE
feat(anime): group and filter episodes by season with chips

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -79,6 +79,7 @@ import eu.kanade.presentation.browse.RelatedMangaTitle
 import eu.kanade.presentation.components.relativeDateTimeText
 import eu.kanade.presentation.manga.components.ChapterDownloadAction
 import eu.kanade.presentation.manga.components.ChapterHeader
+import eu.kanade.presentation.manga.components.EpisodeSeasonChips
 import eu.kanade.presentation.manga.components.ExpandableMangaDescription
 import eu.kanade.presentation.manga.components.MangaActionRow
 import eu.kanade.presentation.manga.components.MangaBottomActionMenu
@@ -218,6 +219,10 @@ fun MangaScreen(
     onSeasonClicked: (SeasonAnime) -> Unit,
     onContinueWatchingClicked: ((SeasonAnime) -> Unit)?,
     // <-- AY
+
+    // ANK -->
+    onSeasonFilterSelected: (Int?) -> Unit,
+    // ANK <--
 ) {
     val context = LocalContext.current
     val onCopyTagToClipboard: (tag: String) -> Unit = {
@@ -295,6 +300,9 @@ fun MangaScreen(
             onSeasonClicked = onSeasonClicked,
             onClickContinueWatching = onContinueWatchingClicked,
             // <-- AY
+            // ANK -->
+            onSeasonFilterSelected = onSeasonFilterSelected,
+            // ANK <--
         )
     } else {
         MangaScreenLargeImpl(
@@ -365,6 +373,9 @@ fun MangaScreen(
             onSeasonClicked = onSeasonClicked,
             onClickContinueWatching = onContinueWatchingClicked,
             // <-- AY
+            // ANK -->
+            onSeasonFilterSelected = onSeasonFilterSelected,
+            // ANK <--
         )
     }
 }
@@ -454,6 +465,9 @@ private fun MangaScreenSmallImpl(
     onSeasonClicked: (SeasonAnime) -> Unit,
     onClickContinueWatching: ((SeasonAnime) -> Unit)?,
     // <-- AY
+    // ANK -->
+    onSeasonFilterSelected: (Int?) -> Unit,
+    // ANK <--
 ) {
     // AY -->
     val density = LocalDensity.current
@@ -899,6 +913,22 @@ private fun MangaScreenSmallImpl(
                             )
                         }
                         FetchType.Episodes -> {
+                            // ANK -->
+                            if (state.episodeSeasons.isNotEmpty()) {
+                                item(
+                                    key = EXACT_HEIGHT_KEY_PREFIX + MangaScreenItem.SEASON_CHIPS,
+                                    contentType = MangaScreenItem.SEASON_CHIPS,
+                                    span = { GridItemSpan(maxLineSpan) },
+                                ) {
+                                    EpisodeSeasonChips(
+                                        seasons = state.episodeSeasons,
+                                        selectedSeason = state.selectedSeasonFilter,
+                                        onSelectSeason = onSeasonFilterSelected,
+                                        modifier = Modifier.ignorePadding(offsetGridPaddingPx),
+                                    )
+                                }
+                            }
+                            // ANK <--
                             if (state.airingTime > 0L) {
                                 item(
                                     // AM -->
@@ -1048,6 +1078,9 @@ private fun MangaScreenLargeImpl(
     onSeasonClicked: (SeasonAnime) -> Unit,
     onClickContinueWatching: ((SeasonAnime) -> Unit)?,
     // <-- AY
+    // ANK -->
+    onSeasonFilterSelected: (Int?) -> Unit,
+    // ANK <--
 ) {
     val layoutDirection = LocalLayoutDirection.current
     val density = LocalDensity.current
@@ -1444,6 +1477,22 @@ private fun MangaScreenLargeImpl(
                                 }
 
                                 FetchType.Episodes -> {
+                                    // ANK -->
+                                    if (state.episodeSeasons.isNotEmpty()) {
+                                        item(
+                                            key = EXACT_HEIGHT_KEY_PREFIX + MangaScreenItem.SEASON_CHIPS,
+                                            contentType = MangaScreenItem.SEASON_CHIPS,
+                                            span = { GridItemSpan(maxLineSpan) },
+                                        ) {
+                                            EpisodeSeasonChips(
+                                                seasons = state.episodeSeasons,
+                                                selectedSeason = state.selectedSeasonFilter,
+                                                onSelectSeason = onSeasonFilterSelected,
+                                                modifier = Modifier.ignorePadding(offsetGridPaddingPx),
+                                            )
+                                        }
+                                    }
+                                    // ANK <--
                                     if (state.airingTime > 0L) {
                                         item(
                                             // AM -->

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreenConstants.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreenConstants.kt
@@ -29,4 +29,8 @@ enum class MangaScreenItem {
     // KMK -->
     RELATED_MANGAS,
     // KMK <--
+
+    // ANK -->
+    SEASON_CHIPS,
+    // ANK <--
 }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/EpisodeSeasonChips.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/EpisodeSeasonChips.kt
@@ -1,0 +1,53 @@
+// ANK -->
+package eu.kanade.presentation.manga.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import tachiyomi.i18n.MR
+import tachiyomi.i18n.aniyomi.AYMR
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+
+/**
+ * Horizontally scrollable row of season filter chips, shown above the episode list
+ * when episode names contain two or more distinct seasons (see EpisodeSeasonParser).
+ */
+@Composable
+fun EpisodeSeasonChips(
+    seasons: List<Int>,
+    selectedSeason: Int?,
+    onSelectSeason: (Int?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = MaterialTheme.padding.extraSmall),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+    ) {
+        FilterChip(
+            selected = selectedSeason == null,
+            onClick = { onSelectSeason(null) },
+            label = { Text(text = stringResource(MR.strings.all)) },
+        )
+        seasons.forEach { season ->
+            FilterChip(
+                selected = selectedSeason == season,
+                onClick = { onSelectSeason(season) },
+                label = { Text(text = stringResource(AYMR.strings.display_mode_season, season.toString())) },
+            )
+        }
+    }
+}
+// ANK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -480,6 +480,9 @@ class MangaScreen(
                 }
             },
             // <-- AY
+            // ANK -->
+            onSeasonFilterSelected = screenModel::setSeasonFilter,
+            // ANK <--
         )
 
         var showScanlatorsDialog by remember { mutableStateOf(false) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -82,6 +82,7 @@ import eu.kanade.tachiyomi.ui.player.settings.GesturePreferences
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
 import eu.kanade.tachiyomi.util.AniChartApi
 import eu.kanade.tachiyomi.util.chapter.getNextUnread
+import eu.kanade.tachiyomi.util.episode.EpisodeSeasonParser
 import eu.kanade.tachiyomi.util.removeCovers
 import eu.kanade.tachiyomi.util.system.getBitmapOrNull
 import eu.kanade.tachiyomi.util.system.toast
@@ -2395,6 +2396,12 @@ class MangaScreenModel(
         updateSuccessState { it.copy(dialog = Dialog.DeleteChapters(chapters)) }
     }
 
+    // ANK -->
+    fun setSeasonFilter(season: Int?) {
+        updateSuccessState { it.copy(selectedSeasonFilter = season) }
+    }
+    // ANK <--
+
     fun showSettingsDialog() {
         updateSuccessState {
             // AY -->
@@ -2491,6 +2498,10 @@ class MangaScreenModel(
             val hideMissingChapters: Boolean = false,
             val trackItems: List<TrackItem> = emptyList(),
 
+            // ANK -->
+            val selectedSeasonFilter: Int? = null,
+            // ANK <--
+
             // AY -->
             val nextAiringEpisode: Pair<Int, Long> = Pair(
                 manga.nextEpisodeToAir,
@@ -2538,12 +2549,31 @@ class MangaScreenModel(
             }
             // <-- AY
 
+            // ANK -->
+            /**
+             * Distinct season numbers detected from episode names, sorted ascending.
+             * Empty when fewer than 2 seasons are detected (nothing to group/filter by).
+             */
+            val episodeSeasons: List<Int> by lazy {
+                if (manga.fetchType != FetchType.Episodes) {
+                    return@lazy emptyList()
+                }
+                chapters.map { it.seasonNumber() }.distinct().sorted().takeIf { it.size >= 2 }.orEmpty()
+            }
+            // ANK <--
+
             val processedChapters by lazy {
                 chapters.applyFilters(manga).toList()
                     // KMK -->
                     // safe-guard some edge-cases where chapters are duplicated some how on a merged entry
                     .distinctBy { it.id }
-                // KMK <--
+                    // KMK <--
+                    // ANK -->
+                    .let { list ->
+                        val season = selectedSeasonFilter
+                        if (season == null) list else list.filter { it.seasonNumber() == season }
+                    }
+                // ANK <--
             }
 
             val chapterListItems by lazy {
@@ -2603,6 +2633,15 @@ class MangaScreenModel(
                     FetchType.Seasons -> manga.seasonsFiltered()
                 }
             // <-- AY
+
+            // ANK -->
+            /**
+             * Season number parsed from the episode's name, defaulting to 1 when no
+             * season marker is found (see [EpisodeSeasonParser]).
+             */
+            private fun ChapterList.Item.seasonNumber(): Int =
+                EpisodeSeasonParser.parseSeason(chapter.name) ?: 1
+            // ANK <--
 
             /**
              * Applies the view filters to the list of chapters obtained from the database.

--- a/app/src/main/java/eu/kanade/tachiyomi/util/episode/EpisodeSeasonParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/episode/EpisodeSeasonParser.kt
@@ -1,0 +1,26 @@
+// ANK -->
+package eu.kanade.tachiyomi.util.episode
+
+/**
+ * Best-effort extraction of a season number from an episode's display name.
+ *
+ * Sources rarely expose season metadata directly, so this looks for common
+ * naming conventions (e.g. "Season 2", "S2E05", "2nd Season") inside the
+ * episode name itself. Returns null when no marker is found.
+ */
+object EpisodeSeasonParser {
+
+    private val SEASON_WORD_REGEX = Regex("""season\s*0*(\d+)""", RegexOption.IGNORE_CASE)
+    private val SEASON_ABBREVIATION_REGEX = Regex(
+        """(?<![a-z0-9])s0*(\d{1,3})(?=e\d|ep\d|[^a-z0-9]|$)""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val SEASON_ORDINAL_REGEX = Regex("""(\d+)(?:st|nd|rd|th)\s*season""", RegexOption.IGNORE_CASE)
+
+    fun parseSeason(episodeName: String): Int? {
+        return SEASON_ORDINAL_REGEX.find(episodeName)?.groupValues?.get(1)?.toIntOrNull()
+            ?: SEASON_WORD_REGEX.find(episodeName)?.groupValues?.get(1)?.toIntOrNull()
+            ?: SEASON_ABBREVIATION_REGEX.find(episodeName)?.groupValues?.get(1)?.toIntOrNull()
+    }
+}
+// ANK <--

--- a/app/src/test/java/eu/kanade/tachiyomi/util/episode/EpisodeSeasonParserTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/episode/EpisodeSeasonParserTest.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.util.episode
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class EpisodeSeasonParserTest {
+
+    @Test
+    fun `matches Season N word form`() {
+        assertEquals(2, EpisodeSeasonParser.parseSeason("Season 2 Episode 5"))
+    }
+
+    @Test
+    fun `matches SN abbreviation form`() {
+        assertEquals(2, EpisodeSeasonParser.parseSeason("S2 - Ep 05"))
+    }
+
+    @Test
+    fun `matches zero-padded SN abbreviation form`() {
+        assertEquals(2, EpisodeSeasonParser.parseSeason("S02E05"))
+    }
+
+    @Test
+    fun `matches ordinal Season form`() {
+        assertEquals(2, EpisodeSeasonParser.parseSeason("2nd Season - 05"))
+    }
+
+    @Test
+    fun `returns null when no season marker present`() {
+        assertNull(EpisodeSeasonParser.parseSeason("Episode 24"))
+    }
+
+    @Test
+    fun `does not match stray S with no digit`() {
+        assertNull(EpisodeSeasonParser.parseSeason("Special Episode"))
+    }
+}


### PR DESCRIPTION
## Summary
- Parses season markers out of episode names ("Season 2", "S2E05", "2nd Season", ...) via a new `EpisodeSeasonParser`
- When 2+ seasons are detected for an entry, a horizontally scrollable chip row (All / Season 1 / Season 2 / ...) appears below the episode count header, letting users filter the episode list to a single season
- No DB or source changes — everything is computed client-side from the existing episode name, same as the app's existing missing-episode-count logic
- Falls back to today's unchanged flat list when fewer than 2 seasons are detected

Closes #251

## Test plan
- [x] Added `EpisodeSeasonParserTest` (6 cases: word form, abbreviation, zero-padded abbreviation, ordinal form, no marker, stray "S" negative) — written test-first, watched it fail before implementing the parser
- [x] `./gradlew :app:testReleaseUnitTest` — all tests pass
- [x] `./gradlew spotlessCheck` — passes
- [x] `./gradlew :app:compileDebugKotlin` — passes
- [x] Manually verified on an emulator with a local-source test anime (12 Season 1 + 12 Season 2 episodes): chips render automatically, "Season 1"/"Season 2" filter down to 12 episodes each, "All" restores all 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add client-side season grouping and filtering for anime episodes based on season information in episode names.

New Features:
- Add client-side detection of season markers in episode names and expose season filter chips when multiple seasons are present.

Enhancements:
- Preserve the existing flat episode list when fewer than two seasons are detected while supporting filtering by season when grouping is available.

Tests:
- Add unit coverage for common season-name formats and invalid season markers.