### PR TITLE
fix(cover-fetcher): ensure unique cache keys for entries without cover/background

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -352,6 +352,10 @@ class MangaCoverFetcher(
         force: Boolean = false,
     ) {
         if (!preloadLibraryColor) return
+        // ANK -->
+        // Cover ratio & colors must not be derived from a background image
+        if (options.useBackground) return
+        // ANK <--
         scope.launch {
             MangaCoverMetadata.setRatioAndColors(mangaCover, bufferedSource, ogFile, onlyFavorite, force)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
@@ -15,10 +15,15 @@ class MangaKeyer : Keyer<DomainManga> {
         // AY -->
         return when {
             options.useBackground && data.hasCustomBackground() -> "${data.id};${data.backgroundLastModified}"
-            options.useBackground -> "${data.backgroundUrl};${data.backgroundLastModified}"
+            // ANK -->
+            options.useBackground ->
+                "${data.backgroundUrl.orKeyOf("background-none", data.id)};${data.backgroundLastModified}"
+            // ANK <--
             // <-- AY
             data.hasCustomCover() -> "${data.id};${data.coverLastModified}"
-            else -> "${data.thumbnailUrl};${data.coverLastModified}"
+            // ANK -->
+            else -> "${data.thumbnailUrl.orKeyOf("cover-none", data.id)};${data.coverLastModified}"
+            // ANK <--
         }
     }
 }
@@ -30,7 +35,20 @@ class MangaCoverKeyer(
         return if (coverCache.getCustomCoverFile(data.mangaId).exists()) {
             "${data.mangaId};${data.lastModified}"
         } else {
-            "${data.url};${data.lastModified}"
+            // ANK -->
+            "${data.url.orKeyOf("cover-none", data.mangaId)};${data.lastModified}"
+            // ANK <--
         }
     }
 }
+
+// ANK -->
+/**
+ * Entries without a cover/background would all resolve to the very same cache key (ie. `"null;0"`),
+ * so Coil's memory & disk cache would happily serve an unrelated entry's image for any of them.
+ * Fall back to an id based key to keep every entry unique.
+ */
+private fun String?.orKeyOf(prefix: String, id: Long): String {
+    return if (isNullOrEmpty()) "$prefix;$id" else this
+}
+// ANK <--


### PR DESCRIPTION
## Summary by Sourcery

Ensure cover and background caching remains unique and metadata is sourced only from covers.

Bug Fixes:
- Prevent cover and background cache collisions for manga entries that do not have corresponding URLs.
- Avoid deriving library cover metadata from background images.

Enhancements:
- Use entry-specific fallback cache keys when cover or background URLs are missing.